### PR TITLE
SpriteRenderComponent

### DIFF
--- a/Source/AGS.API/AGS.API.csproj
+++ b/Source/AGS.API/AGS.API.csproj
@@ -36,6 +36,7 @@
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="Graphics\IImageComponent.cs" />
+    <Compile Include="Graphics\ISpriteRenderComponent.cs" />
     <Compile Include="Objects\Collisions\IPixelPerfectCollidable.cs" />
     <Compile Include="Objects\IDraggableComponent.cs" />
     <Compile Include="Objects\IRotateComponent.cs" />

--- a/Source/AGS.API/Graphics/Animations/IAnimationComponent.cs
+++ b/Source/AGS.API/Graphics/Animations/IAnimationComponent.cs
@@ -15,23 +15,10 @@ namespace AGS.API
 		IAnimation Animation { get; }
 
         /// <summary>
-        /// Gets or sets a value indicating whether the pivot (the pivot point for position/rotate/scale) will 
-        /// be drawn on the screen as a cross. This can be used for debugging the game.
-        /// </summary>
-        /// <value><c>true</c> if debug draw pivot; otherwise, <c>false</c>.</value>
-		bool DebugDrawPivot { get; set; }
-
-        /// <summary>
         /// An event when fires whenever an animation is started on this container.
         /// </summary>
         /// <value>The event.</value>
         IBlockingEvent OnAnimationStarted { get; }
-
-        /// <summary>
-        /// Gets or sets a border that will (optionally) surround the animation.
-        /// </summary>
-        /// <value>The border.</value>
-		IBorderStyle Border { get; set; }
 
         /// <summary>
         /// Starts a new animation (this does not wait for the animation to complete).

--- a/Source/AGS.API/Graphics/ISpriteRenderComponent.cs
+++ b/Source/AGS.API/Graphics/ISpriteRenderComponent.cs
@@ -1,0 +1,48 @@
+﻿using System.ComponentModel;
+
+namespace AGS.API
+{
+    /// <summary>
+    /// Interface of a single sprite source.
+    /// </summary>
+    public interface ISpriteProvider : INotifyPropertyChanged
+    {
+        /// <summary>
+        /// Gets a sprite to work with.
+        /// </summary>
+        /// <value>The sprite.</value>
+        ISprite Sprite { get; }
+    }
+
+    /// <summary>
+    /// A component that renders an entity using 2D sprites.
+    /// A sprite and other properties may be set either by user or by other components.
+    /// </summary>
+    public interface ISpriteRenderComponent : IComponent
+    {
+        /// <summary>
+        /// Gets sprite to render.
+        /// </summary>
+        /// <value>The sprite.</value>
+        ISprite CurrentSprite { get; }
+
+        /// <summary>
+        /// Gets or sets sprite provider.
+        /// </summary>
+        /// <value>The sprite provider implementation.</value>
+        ISpriteProvider SpriteProvider { get; set; }
+
+        /// <summary>
+        /// Gets or sets a value indicating whether the pivot (the pivot point for position/rotate/scale) will 
+        /// be drawn on the screen as a cross. This can be used for debugging the game.
+        /// </summary>
+        /// <value><c>true</c> if debug draw pivot; otherwise, <c>false</c>.</value>
+		bool DebugDrawPivot { get; set; }
+
+        /// <summary>
+        /// Gets or sets a border that will (optionally) surround the sprite.
+        /// </summary>
+        /// <value>The border.</value>
+		IBorderStyle Border { get; set; }
+    }
+}

--- a/Source/AGS.API/Objects/IObject.cs
+++ b/Source/AGS.API/Objects/IObject.cs
@@ -4,7 +4,7 @@
     /// An object is an entity with pre-set components (like location, scale, rotation, animation, etc) which is useful
     /// to depict all adventure game objects. Both characters and UI controls are also objects (with additional components).
     /// </summary>
-	public interface IObject : IEntity, IHasRoomComponent, IAnimationComponent, IInObjectTreeComponent, IColliderComponent, 
+	public interface IObject : IEntity, IHasRoomComponent, ISpriteRenderComponent, IAnimationComponent, IInObjectTreeComponent, IColliderComponent, 
 		IVisibleComponent, IEnabledComponent, ICustomPropertiesComponent, IDrawableInfoComponent, IHotspotComponent, 
         IShaderComponent, ITranslateComponent, IImageComponent, IScaleComponent, IRotateComponent, 
         IPixelPerfectComponent, IHasModelMatrix, IModelMatrixComponent, IBoundingBoxComponent

--- a/Source/Engine/AGS.Engine/AGS.Engine.csproj
+++ b/Source/Engine/AGS.Engine/AGS.Engine.csproj
@@ -58,6 +58,7 @@
       <AutoGen>True</AutoGen>
       <DesignTime>True</DesignTime>
     </Compile>
+    <Compile Include="Graphics\Drawing\AGSSpriteRenderComponent.cs" />
     <Compile Include="Graphics\Image\AGSHasImage.cs" />
     <Compile Include="Graphics\Image\AGSImageComponent.cs" />
     <Compile Include="Graphics\Logic\Interfaces\IGLUtils.cs" />
@@ -213,6 +214,7 @@
     <Compile Include="Serialization\AGSSerializationContext.cs" />
     <Compile Include="Serialization\Contract.cs" />
     <Compile Include="Serialization\Contracts\ContractAnimation.cs" />
+    <Compile Include="Serialization\Contracts\ContractSpriteRenderComponent.cs" />
     <Compile Include="Serialization\Contracts\ContractAnimationConfiguration.cs" />
     <Compile Include="Serialization\Contracts\ContractAnimationComponent.cs" />
     <Compile Include="Serialization\Contracts\ContractAnimationFrame.cs" />

--- a/Source/Engine/AGS.Engine/ComponentsFramework/Templates/AGSButton.generated.cs
+++ b/Source/Engine/AGS.Engine/ComponentsFramework/Templates/AGSButton.generated.cs
@@ -18,6 +18,7 @@ namespace AGS.Engine
         private IUIEvents _uIEvents;
         private ISkinComponent _skinComponent;
         private IHasRoomComponent _hasRoom;
+        private ISpriteRenderComponent _spriteRender;
         private IAnimationComponent _animationContainer;
         private IInObjectTreeComponent _inObjectTree;
         private IColliderComponent _collider;
@@ -44,7 +45,9 @@ namespace AGS.Engine
             _skinComponent = AddComponent<ISkinComponent>();
             Bind<ISkinComponent>(c => _skinComponent = c, _ => {});            
             _hasRoom = AddComponent<IHasRoomComponent>();
-            Bind<IHasRoomComponent>(c => _hasRoom = c, _ => {});            
+            Bind<IHasRoomComponent>(c => _hasRoom = c, _ => {});
+            _spriteRender = AddComponent<ISpriteRenderComponent>();
+            Bind<ISpriteRenderComponent>(c => _spriteRender = c, _ => { });
             _animationContainer = AddComponent<IAnimationComponent>();
             Bind<IAnimationComponent>(c => _animationContainer = c, _ => {});            
             _inObjectTree = AddComponent<IInObjectTreeComponent>();
@@ -186,6 +189,33 @@ namespace AGS.Engine
 
         #endregion
 
+        #region ISpriteRender implementation
+
+        public ISprite CurrentSprite
+        {
+            get { return _spriteRender.CurrentSprite; }
+        }
+
+        public ISpriteProvider SpriteProvider
+        {
+            get { return _spriteRender.SpriteProvider; }
+            set { _spriteRender.SpriteProvider = value; }
+        }
+
+        public Boolean DebugDrawPivot
+        {
+            get { return _spriteRender.DebugDrawPivot; }
+            set { _spriteRender.DebugDrawPivot = value; }
+        }
+
+        public IBorderStyle Border
+        {
+            get { return _spriteRender.Border; }
+            set { _spriteRender.Border = value; }
+        }
+
+        #endregion
+
         #region IAnimationContainer implementation
 
         public IAnimation Animation 
@@ -193,21 +223,9 @@ namespace AGS.Engine
             get { return _animationContainer.Animation; } 
         }
 
-        public Boolean DebugDrawPivot 
-        {  
-            get { return _animationContainer.DebugDrawPivot; }  
-            set { _animationContainer.DebugDrawPivot = value; } 
-        }
-
         public IBlockingEvent OnAnimationStarted 
         {  
             get { return _animationContainer.OnAnimationStarted; } 
-        }
-
-        public IBorderStyle Border 
-        {  
-            get { return _animationContainer.Border; }  
-            set { _animationContainer.Border = value; } 
         }
 
         public void StartAnimation(IAnimation animation)

--- a/Source/Engine/AGS.Engine/ComponentsFramework/Templates/AGSCharacter.generated.cs
+++ b/Source/Engine/AGS.Engine/ComponentsFramework/Templates/AGSCharacter.generated.cs
@@ -17,6 +17,7 @@ namespace AGS.Engine
     public partial class AGSCharacter : AGSEntity, ICharacter
     {
         private IHasRoomComponent _hasRoom;
+        private ISpriteRenderComponent _spriteRender;
         private IAnimationComponent _animationContainer;
         private IInObjectTreeComponent _inObjectTree;
         private IColliderComponent _collider;
@@ -43,7 +44,9 @@ namespace AGS.Engine
         public AGSCharacter(string id, Resolver resolver, IOutfit outfit) : base(id, resolver)
         {            
             _hasRoom = AddComponent<IHasRoomComponent>();
-            Bind<IHasRoomComponent>(c => _hasRoom = c, _ => {});            
+            Bind<IHasRoomComponent>(c => _hasRoom = c, _ => {});
+            _spriteRender = AddComponent<ISpriteRenderComponent>();
+            Bind<ISpriteRenderComponent>(c => _spriteRender = c, _ => { });
             _animationContainer = AddComponent<IAnimationComponent>();
             Bind<IAnimationComponent>(c => _animationContainer = c, _ => {});            
             _inObjectTree = AddComponent<IInObjectTreeComponent>();
@@ -120,6 +123,33 @@ namespace AGS.Engine
 
         #endregion
 
+        #region ISpriteRender implementation
+
+        public ISprite CurrentSprite
+        {
+            get { return _spriteRender.CurrentSprite; }
+        }
+
+        public ISpriteProvider SpriteProvider
+        {
+            get { return _spriteRender.SpriteProvider; }
+            set { _spriteRender.SpriteProvider = value; }
+        }
+
+        public Boolean DebugDrawPivot
+        {
+            get { return _spriteRender.DebugDrawPivot; }
+            set { _spriteRender.DebugDrawPivot = value; }
+        }
+
+        public IBorderStyle Border
+        {
+            get { return _spriteRender.Border; }
+            set { _spriteRender.Border = value; }
+        }
+
+        #endregion
+
         #region IAnimationContainer implementation
 
         public IAnimation Animation 
@@ -127,21 +157,9 @@ namespace AGS.Engine
             get { return _animationContainer.Animation; } 
         }
 
-        public Boolean DebugDrawPivot 
-        {  
-            get { return _animationContainer.DebugDrawPivot; }  
-            set { _animationContainer.DebugDrawPivot = value; } 
-        }
-
         public IBlockingEvent OnAnimationStarted 
         {  
             get { return _animationContainer.OnAnimationStarted; } 
-        }
-
-        public IBorderStyle Border 
-        {  
-            get { return _animationContainer.Border; }  
-            set { _animationContainer.Border = value; } 
         }
 
         public void StartAnimation(IAnimation animation)

--- a/Source/Engine/AGS.Engine/ComponentsFramework/Templates/AGSCheckbox.generated.cs
+++ b/Source/Engine/AGS.Engine/ComponentsFramework/Templates/AGSCheckbox.generated.cs
@@ -18,6 +18,7 @@ namespace AGS.Engine
         private IUIEvents _uIEvents;
         private ISkinComponent _skinComponent;
         private IHasRoomComponent _hasRoom;
+        private ISpriteRenderComponent _spriteRender;
         private IAnimationComponent _animationContainer;
         private IInObjectTreeComponent _inObjectTree;
         private IColliderComponent _collider;
@@ -45,6 +46,8 @@ namespace AGS.Engine
             _hasRoom = AddComponent<IHasRoomComponent>();
             Bind<IHasRoomComponent>(c => _hasRoom = c, _ => {});            
             _animationContainer = AddComponent<IAnimationComponent>();
+            _spriteRender = AddComponent<ISpriteRenderComponent>();
+            Bind<ISpriteRenderComponent>(c => _spriteRender = c, _ => { });
             Bind<IAnimationComponent>(c => _animationContainer = c, _ => {});            
             _inObjectTree = AddComponent<IInObjectTreeComponent>();
             Bind<IInObjectTreeComponent>(c => _inObjectTree = c, _ => {});            
@@ -183,6 +186,33 @@ namespace AGS.Engine
 
         #endregion
 
+        #region ISpriteRender implementation
+
+        public ISprite CurrentSprite
+        {
+            get { return _spriteRender.CurrentSprite; }
+        }
+
+        public ISpriteProvider SpriteProvider
+        {
+            get { return _spriteRender.SpriteProvider; }
+            set { _spriteRender.SpriteProvider = value; }
+        }
+
+        public Boolean DebugDrawPivot
+        {
+            get { return _spriteRender.DebugDrawPivot; }
+            set { _spriteRender.DebugDrawPivot = value; }
+        }
+
+        public IBorderStyle Border
+        {
+            get { return _spriteRender.Border; }
+            set { _spriteRender.Border = value; }
+        }
+
+        #endregion
+
         #region IAnimationContainer implementation
 
         public IAnimation Animation 
@@ -190,21 +220,9 @@ namespace AGS.Engine
             get { return _animationContainer.Animation; } 
         }
 
-        public Boolean DebugDrawPivot 
-        {  
-            get { return _animationContainer.DebugDrawPivot; }  
-            set { _animationContainer.DebugDrawPivot = value; } 
-        }
-
         public IBlockingEvent OnAnimationStarted 
         {  
             get { return _animationContainer.OnAnimationStarted; } 
-        }
-
-        public IBorderStyle Border 
-        {  
-            get { return _animationContainer.Border; }  
-            set { _animationContainer.Border = value; } 
         }
 
         public void StartAnimation(IAnimation animation)

--- a/Source/Engine/AGS.Engine/ComponentsFramework/Templates/AGSComboBox.generated.cs
+++ b/Source/Engine/AGS.Engine/ComponentsFramework/Templates/AGSComboBox.generated.cs
@@ -19,6 +19,7 @@ namespace AGS.Engine
         private IUIEvents _uIEvents;
         private ISkinComponent _skinComponent;
         private IHasRoomComponent _hasRoom;
+        private ISpriteRenderComponent _spriteRender;
         private IAnimationComponent _animationContainer;
         private IInObjectTreeComponent _inObjectTree;
         private IColliderComponent _collider;
@@ -45,7 +46,9 @@ namespace AGS.Engine
             _skinComponent = AddComponent<ISkinComponent>();
             Bind<ISkinComponent>(c => _skinComponent = c, _ => {});            
             _hasRoom = AddComponent<IHasRoomComponent>();
-            Bind<IHasRoomComponent>(c => _hasRoom = c, _ => {});            
+            Bind<IHasRoomComponent>(c => _hasRoom = c, _ => {});
+            _spriteRender = AddComponent<ISpriteRenderComponent>();
+            Bind<ISpriteRenderComponent>(c => _spriteRender = c, _ => { });
             _animationContainer = AddComponent<IAnimationComponent>();
             Bind<IAnimationComponent>(c => _animationContainer = c, _ => {});            
             _inObjectTree = AddComponent<IInObjectTreeComponent>();
@@ -210,6 +213,33 @@ namespace AGS.Engine
 
         #endregion
 
+        #region ISpriteRender implementation
+
+        public ISprite CurrentSprite
+        {
+            get { return _spriteRender.CurrentSprite; }
+        }
+
+        public ISpriteProvider SpriteProvider
+        {
+            get { return _spriteRender.SpriteProvider; }
+            set { _spriteRender.SpriteProvider = value; }
+        }
+
+        public Boolean DebugDrawPivot
+        {
+            get { return _spriteRender.DebugDrawPivot; }
+            set { _spriteRender.DebugDrawPivot = value; }
+        }
+
+        public IBorderStyle Border
+        {
+            get { return _spriteRender.Border; }
+            set { _spriteRender.Border = value; }
+        }
+
+        #endregion
+
         #region IAnimationContainer implementation
 
         public IAnimation Animation 
@@ -217,21 +247,9 @@ namespace AGS.Engine
             get { return _animationContainer.Animation; } 
         }
 
-        public Boolean DebugDrawPivot 
-        {  
-            get { return _animationContainer.DebugDrawPivot; }  
-            set { _animationContainer.DebugDrawPivot = value; } 
-        }
-
         public IBlockingEvent OnAnimationStarted 
         {  
             get { return _animationContainer.OnAnimationStarted; } 
-        }
-
-        public IBorderStyle Border 
-        {  
-            get { return _animationContainer.Border; }  
-            set { _animationContainer.Border = value; } 
         }
 
         public void StartAnimation(IAnimation animation)

--- a/Source/Engine/AGS.Engine/ComponentsFramework/Templates/AGSInventoryWindow.generated.cs
+++ b/Source/Engine/AGS.Engine/ComponentsFramework/Templates/AGSInventoryWindow.generated.cs
@@ -18,6 +18,7 @@ namespace AGS.Engine
         private IUIEvents _uIEvents;
         private ISkinComponent _skinComponent;
         private IHasRoomComponent _hasRoom;
+        private ISpriteRenderComponent _spriteRender;
         private IAnimationComponent _animationComponent;
         private IInObjectTreeComponent _inObjectTree;
         private IColliderComponent _collider;
@@ -43,7 +44,9 @@ namespace AGS.Engine
             _skinComponent = AddComponent<ISkinComponent>();
             Bind<ISkinComponent>(c => _skinComponent = c, _ => {});            
             _hasRoom = AddComponent<IHasRoomComponent>();
-            Bind<IHasRoomComponent>(c => _hasRoom = c, _ => {});            
+            Bind<IHasRoomComponent>(c => _hasRoom = c, _ => {});
+            _spriteRender = AddComponent<ISpriteRenderComponent>();
+            Bind<ISpriteRenderComponent>(c => _spriteRender = c, _ => { });
             _animationComponent = AddComponent<IAnimationComponent>();
             Bind<IAnimationComponent>(c => _animationComponent = c, _ => {});            
             _inObjectTree = AddComponent<IInObjectTreeComponent>();
@@ -183,6 +186,33 @@ namespace AGS.Engine
 
         #endregion
 
+        #region ISpriteRender implementation
+
+        public ISprite CurrentSprite
+        {
+            get { return _spriteRender.CurrentSprite; }
+        }
+
+        public ISpriteProvider SpriteProvider
+        {
+            get { return _spriteRender.SpriteProvider; }
+            set { _spriteRender.SpriteProvider = value; }
+        }
+
+        public Boolean DebugDrawPivot
+        {
+            get { return _spriteRender.DebugDrawPivot; }
+            set { _spriteRender.DebugDrawPivot = value; }
+        }
+
+        public IBorderStyle Border
+        {
+            get { return _spriteRender.Border; }
+            set { _spriteRender.Border = value; }
+        }
+
+        #endregion
+
         #region IAnimationContainer implementation
 
         public IAnimation Animation 
@@ -190,21 +220,9 @@ namespace AGS.Engine
             get { return _animationComponent.Animation; } 
         }
 
-        public Boolean DebugDrawPivot 
-        {  
-            get { return _animationComponent.DebugDrawPivot; }  
-            set { _animationComponent.DebugDrawPivot = value; } 
-        }
-
         public IBlockingEvent OnAnimationStarted 
         {  
             get { return _animationComponent.OnAnimationStarted; } 
-        }
-
-        public IBorderStyle Border 
-        {  
-            get { return _animationComponent.Border; }  
-            set { _animationComponent.Border = value; } 
         }
 
         public void StartAnimation(IAnimation animation)

--- a/Source/Engine/AGS.Engine/ComponentsFramework/Templates/AGSLabel.generated.cs
+++ b/Source/Engine/AGS.Engine/ComponentsFramework/Templates/AGSLabel.generated.cs
@@ -19,6 +19,7 @@ namespace AGS.Engine
         private IUIEvents _uIEvents;
         private ISkinComponent _skinComponent;
         private IHasRoomComponent _hasRoom;
+        private ISpriteRenderComponent _spriteRender;
         private IAnimationComponent _animationContainer;
         private IInObjectTreeComponent _inObjectTree;
         private IColliderComponent _collider;
@@ -45,7 +46,9 @@ namespace AGS.Engine
             _skinComponent = AddComponent<ISkinComponent>();
             Bind<ISkinComponent>(c => _skinComponent = c, _ => {});            
             _hasRoom = AddComponent<IHasRoomComponent>();
-            Bind<IHasRoomComponent>(c => _hasRoom = c, _ => {});            
+            Bind<IHasRoomComponent>(c => _hasRoom = c, _ => {});
+            _spriteRender = AddComponent<ISpriteRenderComponent>();
+            Bind<ISpriteRenderComponent>(c => _spriteRender = c, _ => { });
             _animationContainer = AddComponent<IAnimationComponent>();
             Bind<IAnimationComponent>(c => _animationContainer = c, _ => {});            
             _inObjectTree = AddComponent<IInObjectTreeComponent>();
@@ -227,6 +230,33 @@ namespace AGS.Engine
 
         #endregion
 
+        #region ISpriteRender implementation
+
+        public ISprite CurrentSprite
+        {
+            get { return _spriteRender.CurrentSprite; }
+        }
+
+        public ISpriteProvider SpriteProvider
+        {
+            get { return _spriteRender.SpriteProvider; }
+            set { _spriteRender.SpriteProvider = value; }
+        }
+
+        public Boolean DebugDrawPivot
+        {
+            get { return _spriteRender.DebugDrawPivot; }
+            set { _spriteRender.DebugDrawPivot = value; }
+        }
+
+        public IBorderStyle Border
+        {
+            get { return _spriteRender.Border; }
+            set { _spriteRender.Border = value; }
+        }
+
+        #endregion
+
         #region IAnimationContainer implementation
 
         public IAnimation Animation 
@@ -234,21 +264,9 @@ namespace AGS.Engine
             get { return _animationContainer.Animation; } 
         }
 
-        public Boolean DebugDrawPivot 
-        {  
-            get { return _animationContainer.DebugDrawPivot; }  
-            set { _animationContainer.DebugDrawPivot = value; } 
-        }
-
         public IBlockingEvent OnAnimationStarted 
         {  
             get { return _animationContainer.OnAnimationStarted; } 
-        }
-
-        public IBorderStyle Border 
-        {  
-            get { return _animationContainer.Border; }  
-            set { _animationContainer.Border = value; } 
         }
 
         public void StartAnimation(IAnimation animation)

--- a/Source/Engine/AGS.Engine/ComponentsFramework/Templates/AGSObject.generated.cs
+++ b/Source/Engine/AGS.Engine/ComponentsFramework/Templates/AGSObject.generated.cs
@@ -16,6 +16,7 @@ namespace AGS.Engine
     public partial class AGSObject : AGSEntity, IObject
     {
         private IHasRoomComponent _hasRoom;
+        private ISpriteRenderComponent _spriteRender;
         private IAnimationComponent _animationContainer;
         private IInObjectTreeComponent _inObjectTree;
         private IColliderComponent _collider;
@@ -36,7 +37,9 @@ namespace AGS.Engine
         public AGSObject(string id, Resolver resolver) : base(id, resolver)
         {            
             _hasRoom = AddComponent<IHasRoomComponent>();
-            Bind<IHasRoomComponent>(c => _hasRoom = c, _ => {});            
+            Bind<IHasRoomComponent>(c => _hasRoom = c, _ => {});
+            _spriteRender = AddComponent<ISpriteRenderComponent>();
+            Bind<ISpriteRenderComponent>(c => _spriteRender = c, _ => { });
             _animationContainer = AddComponent<IAnimationComponent>();
             Bind<IAnimationComponent>(c => _animationContainer = c, _ => {});            
             _inObjectTree = AddComponent<IInObjectTreeComponent>();
@@ -110,6 +113,33 @@ namespace AGS.Engine
 
         #endregion
 
+        #region ISpriteRender implementation
+
+        public ISprite CurrentSprite
+        {
+            get { return _spriteRender.CurrentSprite; }
+        }
+
+        public ISpriteProvider SpriteProvider
+        {
+            get { return _spriteRender.SpriteProvider; }
+            set { _spriteRender.SpriteProvider = value; }
+        }
+
+        public Boolean DebugDrawPivot
+        {
+            get { return _spriteRender.DebugDrawPivot; }
+            set { _spriteRender.DebugDrawPivot = value; }
+        }
+
+        public IBorderStyle Border
+        {
+            get { return _spriteRender.Border; }
+            set { _spriteRender.Border = value; }
+        }
+
+        #endregion
+
         #region IAnimationContainer implementation
 
         public IAnimation Animation 
@@ -117,21 +147,9 @@ namespace AGS.Engine
             get { return _animationContainer.Animation; } 
         }
 
-        public Boolean DebugDrawPivot 
-        {  
-            get { return _animationContainer.DebugDrawPivot; }  
-            set { _animationContainer.DebugDrawPivot = value; } 
-        }
-
         public IBlockingEvent OnAnimationStarted 
         {  
             get { return _animationContainer.OnAnimationStarted; } 
-        }
-
-        public IBorderStyle Border 
-        {  
-            get { return _animationContainer.Border; }  
-            set { _animationContainer.Border = value; } 
         }
 
         public void StartAnimation(IAnimation animation)

--- a/Source/Engine/AGS.Engine/ComponentsFramework/Templates/AGSPanel.generated.cs
+++ b/Source/Engine/AGS.Engine/ComponentsFramework/Templates/AGSPanel.generated.cs
@@ -18,6 +18,7 @@ namespace AGS.Engine
         private IUIEvents _uIEvents;
         private ISkinComponent _skinComponent;
         private IHasRoomComponent _hasRoom;
+        private ISpriteRenderComponent _spriteRender;
         private IAnimationComponent _animationContainer;
         private IInObjectTreeComponent _inObjectTree;
         private IColliderComponent _collider;
@@ -42,7 +43,9 @@ namespace AGS.Engine
             _skinComponent = AddComponent<ISkinComponent>();
             Bind<ISkinComponent>(c => _skinComponent = c, _ => {});            
             _hasRoom = AddComponent<IHasRoomComponent>();
-            Bind<IHasRoomComponent>(c => _hasRoom = c, _ => {});            
+            Bind<IHasRoomComponent>(c => _hasRoom = c, _ => {});
+            _spriteRender = AddComponent<ISpriteRenderComponent>();
+            Bind<ISpriteRenderComponent>(c => _spriteRender = c, _ => { });
             _animationContainer = AddComponent<IAnimationComponent>();
             Bind<IAnimationComponent>(c => _animationContainer = c, _ => {});            
             _inObjectTree = AddComponent<IInObjectTreeComponent>();
@@ -180,6 +183,33 @@ namespace AGS.Engine
 
         #endregion
 
+        #region ISpriteRender implementation
+
+        public ISprite CurrentSprite
+        {
+            get { return _spriteRender.CurrentSprite; }
+        }
+
+        public ISpriteProvider SpriteProvider
+        {
+            get { return _spriteRender.SpriteProvider; }
+            set { _spriteRender.SpriteProvider = value; }
+        }
+
+        public Boolean DebugDrawPivot
+        {
+            get { return _spriteRender.DebugDrawPivot; }
+            set { _spriteRender.DebugDrawPivot = value; }
+        }
+
+        public IBorderStyle Border
+        {
+            get { return _spriteRender.Border; }
+            set { _spriteRender.Border = value; }
+        }
+
+        #endregion
+
         #region IAnimationContainer implementation
 
         public IAnimation Animation 
@@ -187,21 +217,9 @@ namespace AGS.Engine
             get { return _animationContainer.Animation; } 
         }
 
-        public Boolean DebugDrawPivot 
-        {  
-            get { return _animationContainer.DebugDrawPivot; }  
-            set { _animationContainer.DebugDrawPivot = value; } 
-        }
-
         public IBlockingEvent OnAnimationStarted 
         {  
             get { return _animationContainer.OnAnimationStarted; } 
-        }
-
-        public IBorderStyle Border 
-        {  
-            get { return _animationContainer.Border; }  
-            set { _animationContainer.Border = value; } 
         }
 
         public void StartAnimation(IAnimation animation)

--- a/Source/Engine/AGS.Engine/ComponentsFramework/Templates/AGSSlider.generated.cs
+++ b/Source/Engine/AGS.Engine/ComponentsFramework/Templates/AGSSlider.generated.cs
@@ -19,6 +19,7 @@ namespace AGS.Engine
         private IUIEvents _uIEvents;
         private ISkinComponent _skinComponent;
         private IHasRoomComponent _hasRoom;
+        private ISpriteRenderComponent _spriteRender;
         private IAnimationComponent _animationContainer;
         private IInObjectTreeComponent _inObjectTree;
         private IColliderComponent _collider;
@@ -45,7 +46,9 @@ namespace AGS.Engine
             _skinComponent = AddComponent<ISkinComponent>();
             Bind<ISkinComponent>(c => _skinComponent = c, _ => {});            
             _hasRoom = AddComponent<IHasRoomComponent>();
-            Bind<IHasRoomComponent>(c => _hasRoom = c, _ => {});            
+            Bind<IHasRoomComponent>(c => _hasRoom = c, _ => {});
+            _spriteRender = AddComponent<ISpriteRenderComponent>();
+            Bind<ISpriteRenderComponent>(c => _spriteRender = c, _ => { });
             _animationContainer = AddComponent<IAnimationComponent>();
             Bind<IAnimationComponent>(c => _animationContainer = c, _ => {});            
             _inObjectTree = AddComponent<IInObjectTreeComponent>();
@@ -245,6 +248,33 @@ namespace AGS.Engine
 
         #endregion
 
+        #region ISpriteRender implementation
+
+        public ISprite CurrentSprite
+        {
+            get { return _spriteRender.CurrentSprite; }
+        }
+
+        public ISpriteProvider SpriteProvider
+        {
+            get { return _spriteRender.SpriteProvider; }
+            set { _spriteRender.SpriteProvider = value; }
+        }
+
+        public Boolean DebugDrawPivot
+        {
+            get { return _spriteRender.DebugDrawPivot; }
+            set { _spriteRender.DebugDrawPivot = value; }
+        }
+
+        public IBorderStyle Border
+        {
+            get { return _spriteRender.Border; }
+            set { _spriteRender.Border = value; }
+        }
+
+        #endregion
+
         #region IAnimationContainer implementation
 
         public IAnimation Animation 
@@ -252,21 +282,9 @@ namespace AGS.Engine
             get { return _animationContainer.Animation; } 
         }
 
-        public Boolean DebugDrawPivot 
-        {  
-            get { return _animationContainer.DebugDrawPivot; }  
-            set { _animationContainer.DebugDrawPivot = value; } 
-        }
-
         public IBlockingEvent OnAnimationStarted 
         {  
             get { return _animationContainer.OnAnimationStarted; } 
-        }
-
-        public IBorderStyle Border 
-        {  
-            get { return _animationContainer.Border; }  
-            set { _animationContainer.Border = value; } 
         }
 
         public void StartAnimation(IAnimation animation)

--- a/Source/Engine/AGS.Engine/ComponentsFramework/Templates/AGSTextbox.generated.cs
+++ b/Source/Engine/AGS.Engine/ComponentsFramework/Templates/AGSTextbox.generated.cs
@@ -18,6 +18,7 @@ namespace AGS.Engine
         private IUIEvents _uIEvents;
         private ISkinComponent _skinComponent;
         private IHasRoomComponent _hasRoom;
+        private ISpriteRenderComponent _spriteRender;
         private IAnimationComponent _animationContainer;
         private IInObjectTreeComponent _inObjectTree;
         private IColliderComponent _collider;
@@ -44,7 +45,9 @@ namespace AGS.Engine
             _skinComponent = AddComponent<ISkinComponent>();
             Bind<ISkinComponent>(c => _skinComponent = c, _ => {});            
             _hasRoom = AddComponent<IHasRoomComponent>();
-            Bind<IHasRoomComponent>(c => _hasRoom = c, _ => {});            
+            Bind<IHasRoomComponent>(c => _hasRoom = c, _ => {});
+            _spriteRender = AddComponent<ISpriteRenderComponent>();
+            Bind<ISpriteRenderComponent>(c => _spriteRender = c, _ => { });
             _animationContainer = AddComponent<IAnimationComponent>();
             Bind<IAnimationComponent>(c => _animationContainer = c, _ => {});            
             _inObjectTree = AddComponent<IInObjectTreeComponent>();
@@ -186,6 +189,33 @@ namespace AGS.Engine
 
         #endregion
 
+        #region ISpriteRender implementation
+
+        public ISprite CurrentSprite
+        {
+            get { return _spriteRender.CurrentSprite; }
+        }
+
+        public ISpriteProvider SpriteProvider
+        {
+            get { return _spriteRender.SpriteProvider; }
+            set { _spriteRender.SpriteProvider = value; }
+        }
+
+        public Boolean DebugDrawPivot
+        {
+            get { return _spriteRender.DebugDrawPivot; }
+            set { _spriteRender.DebugDrawPivot = value; }
+        }
+
+        public IBorderStyle Border
+        {
+            get { return _spriteRender.Border; }
+            set { _spriteRender.Border = value; }
+        }
+
+        #endregion
+
         #region IAnimationContainer implementation
 
         public IAnimation Animation 
@@ -193,21 +223,9 @@ namespace AGS.Engine
             get { return _animationContainer.Animation; } 
         }
 
-        public Boolean DebugDrawPivot 
-        {  
-            get { return _animationContainer.DebugDrawPivot; }  
-            set { _animationContainer.DebugDrawPivot = value; } 
-        }
-
         public IBlockingEvent OnAnimationStarted 
         {  
             get { return _animationContainer.OnAnimationStarted; } 
-        }
-
-        public IBorderStyle Border 
-        {  
-            get { return _animationContainer.Border; }  
-            set { _animationContainer.Border = value; } 
         }
 
         public void StartAnimation(IAnimation animation)

--- a/Source/Engine/AGS.Engine/Game/Factories/AGSUIFactory.cs
+++ b/Source/Engine/AGS.Engine/Game/Factories/AGSUIFactory.cs
@@ -159,7 +159,7 @@ namespace AGS.Engine
             setParent(button, parent);
 
             button.Skin?.Apply(button);
-            button.IdleAnimation.StartAnimation(button, button, button);
+            button.IdleAnimation.StartAnimation(button, button, button, button);
 
             if (addToUi)
                 _gameState.UI.Add(button);
@@ -282,7 +282,7 @@ namespace AGS.Engine
             setParent(checkbox, parent);
 
             checkbox.Skin?.Apply(checkbox);
-            checkbox.NotCheckedAnimation.StartAnimation(checkbox, checkbox.TextLabel, checkbox);
+            checkbox.NotCheckedAnimation.StartAnimation(checkbox, checkbox.TextLabel, checkbox, checkbox);
 
             if (addToUi)
                 _gameState.UI.Add(checkbox);

--- a/Source/Engine/AGS.Engine/Graphics/Drawing/AGSSpriteRenderComponent.cs
+++ b/Source/Engine/AGS.Engine/Graphics/Drawing/AGSSpriteRenderComponent.cs
@@ -1,0 +1,43 @@
+﻿using System.ComponentModel;
+using AGS.API;
+
+namespace AGS.Engine
+{
+    public class AGSSpriteRenderComponent : AGSComponent, ISpriteRenderComponent
+    {
+        private ISpriteProvider _provider;
+
+        public AGSSpriteRenderComponent()
+        {
+        }
+
+        public ISprite CurrentSprite { get => _provider?.Sprite; }
+
+        public ISpriteProvider SpriteProvider
+        {
+            get => _provider;
+            set
+            {
+                var previousProvider = _provider;
+                if (previousProvider != null)
+                    previousProvider.PropertyChanged -= OnProviderPropertyChanged;
+                if (value != null)
+                    value.PropertyChanged += OnProviderPropertyChanged;
+                _provider = value;
+                OnPropertyChanged(nameof(CurrentSprite));
+            }
+        }
+
+        public bool DebugDrawPivot { get; set; }
+
+        public IBorderStyle Border { get; set; }
+
+        private void OnProviderPropertyChanged(object sender, PropertyChangedEventArgs args)
+        {
+            if (args.PropertyName != nameof(ISpriteProvider.Sprite))
+                return;
+            // resend property changed event to notify that ISpriteRenderComponent.CurrentSprite has new value
+            OnPropertyChanged(nameof(CurrentSprite));
+        }
+    }
+}

--- a/Source/Engine/AGS.Engine/Graphics/Logic/GLImageRenderer.cs
+++ b/Source/Engine/AGS.Engine/Graphics/Logic/GLImageRenderer.cs
@@ -45,7 +45,7 @@ namespace AGS.Engine
 
         public void Render(IObject obj, IViewport viewport)
 		{
-            ISprite sprite = obj.Animation?.Sprite;
+            ISprite sprite = obj.CurrentSprite;
             if (sprite == null || sprite.Image == null)
             {
                 return;

--- a/Source/Engine/AGS.Engine/Misc/Utils/Extensions.cs
+++ b/Source/Engine/AGS.Engine/Misc/Utils/Extensions.cs
@@ -128,7 +128,8 @@ namespace AGS.Engine
         }
 
         public static void StartAnimation(this ButtonAnimation button, IAnimationComponent animationComponent,
-                                          ITextComponent textComponent, IImageComponent imageComponent)
+                                          ITextComponent textComponent, IImageComponent imageComponent,
+                                          ISpriteRenderComponent spriteRender)
         {
             if (button == null) return;
 
@@ -136,7 +137,7 @@ namespace AGS.Engine
             if (animation != null && animation.Frames.Count > 0) animationComponent?.StartAnimation(animation);
 
             var border = button.Border;
-            if (border != null && animationComponent != null) animationComponent.Border = border;
+            if (border != null && spriteRender != null) spriteRender.Border = border;
 
             var textConfig = button.TextConfig;
             if (textConfig != null && textComponent != null) textComponent.TextConfig = textConfig;

--- a/Source/Engine/AGS.Engine/Serialization/Contracts/ContractAnimationComponent.cs
+++ b/Source/Engine/AGS.Engine/Serialization/Contracts/ContractAnimationComponent.cs
@@ -15,12 +15,6 @@ namespace AGS.Engine
 		[ProtoMember(1)]
 		public IContract<IAnimation> Animation { get; set; }
 
-		[ProtoMember(2)]
-        public bool DebugDrawPivot { get; set; }
-
-		[ProtoMember(3)]
-		public IContract<IBorderStyle> Border { get; set; }
-
 		#region IContract implementation
 
 		public IAnimationComponent ToItem(AGSSerializationContext context)
@@ -32,8 +26,6 @@ namespace AGS.Engine
 
 		public void ToItem(AGSSerializationContext context, IAnimationComponent container)
 		{
-			container.DebugDrawPivot = DebugDrawPivot;
-			container.Border = Border.ToItem(context);
 			IAnimation animation = Animation.ToItem(context);
 			if (animation != null)
 			{
@@ -44,9 +36,6 @@ namespace AGS.Engine
 		public void FromItem(AGSSerializationContext context, IAnimationComponent item)
 		{
 			Animation = context.GetContract(item.Animation);
-			Border = context.GetContract(item.Border);
-
-			DebugDrawPivot = item.DebugDrawPivot;			
 		}
 
 		#endregion

--- a/Source/Engine/AGS.Engine/Serialization/Contracts/ContractSpriteRenderComponent.cs
+++ b/Source/Engine/AGS.Engine/Serialization/Contracts/ContractSpriteRenderComponent.cs
@@ -1,0 +1,50 @@
+﻿using System;
+using ProtoBuf;
+using AGS.API;
+
+
+namespace AGS.Engine
+{
+    [ProtoContract]
+    public class ContractSpriteRenderComponent : IContract<ISpriteRenderComponent>
+    {
+        public ContractSpriteRenderComponent()
+        {
+        }
+        
+        [ProtoMember(1)]
+        public IContract<ISpriteProvider> SpriteProvider { get; set; }
+
+        [ProtoMember(2)]
+        public bool DebugDrawPivot { get; set; }
+
+        [ProtoMember(3)]
+        public IContract<IBorderStyle> Border { get; set; }
+
+        #region IContract implementation
+
+        public ISpriteRenderComponent ToItem(AGSSerializationContext context)
+        {
+            AGSSpriteRenderComponent container = new AGSSpriteRenderComponent();
+            ToItem(context, container);
+            return container;
+        }
+
+        public void ToItem(AGSSerializationContext context, ISpriteRenderComponent container)
+        {
+            container.SpriteProvider = SpriteProvider.ToItem(context);
+            container.Border = Border.ToItem(context);
+            container.DebugDrawPivot = DebugDrawPivot;
+        }
+
+        public void FromItem(AGSSerializationContext context, ISpriteRenderComponent item)
+        {
+            SpriteProvider = context.GetContract(item.SpriteProvider);
+            Border = context.GetContract(item.Border);
+            DebugDrawPivot = item.DebugDrawPivot;
+        }
+
+        #endregion
+    }
+}
+

--- a/Source/Engine/AGS.Engine/UI/Controls/Button/AGSButtonComponent.cs
+++ b/Source/Engine/AGS.Engine/UI/Controls/Button/AGSButtonComponent.cs
@@ -5,6 +5,7 @@ namespace AGS.Engine
 	public class AGSButtonComponent : AGSComponent, IButtonComponent
 	{
 		private IUIEvents _events;
+        private ISpriteRenderComponent _spriteRender;
 		private IAnimationComponent _animation;
         private ITextComponent _text;
         private IImageComponent _image;
@@ -12,6 +13,7 @@ namespace AGS.Engine
 		public override void Init(IEntity entity)
 		{
 			base.Init(entity);
+            entity.Bind<ISpriteRenderComponent>(c => _spriteRender = c, _ => _spriteRender = null);
             entity.Bind<IAnimationComponent>(c => _animation = c, _ => _animation = null);
             entity.Bind<ITextComponent>(c => _text = c, _ => _text = null);
             entity.Bind<IImageComponent>(c => _image = c, _ => _image = null);
@@ -62,7 +64,7 @@ namespace AGS.Engine
 
         private void startAnimation(ButtonAnimation button)
         {
-            button.StartAnimation(_animation, _text, _image);
+            button.StartAnimation(_animation, _text, _image, _spriteRender);
         }
 	}
 }

--- a/Source/Engine/AGS.Engine/UI/Controls/Checkbox/AGSCheckboxComponent.cs
+++ b/Source/Engine/AGS.Engine/UI/Controls/Checkbox/AGSCheckboxComponent.cs
@@ -6,6 +6,7 @@ namespace AGS.Engine.UI.Controls
     {
         private bool _checked;
         private IUIEvents _events;
+        private ISpriteRenderComponent _spriteRender;
         private IAnimationComponent _animation;
         private ITextComponent _text;
         private IImageComponent _image;
@@ -18,7 +19,8 @@ namespace AGS.Engine.UI.Controls
         public override void Init(IEntity entity)
         {
             base.Init(entity);
-			entity.Bind<IAnimationComponent>(c => _animation = c, _ => _animation = null);
+            entity.Bind<ISpriteRenderComponent>(c => _spriteRender = c, _ => _spriteRender = null);
+            entity.Bind<IAnimationComponent>(c => _animation = c, _ => _animation = null);
 			entity.Bind<ITextComponent>(c => _text = c, _ => _text = null);
 			entity.Bind<IImageComponent>(c => _image = c, _ => _image = null);
 			entity.Bind<IUIEvents>(c =>
@@ -89,7 +91,7 @@ namespace AGS.Engine.UI.Controls
 
         private void startAnimation(ButtonAnimation button)
         {
-	        button.StartAnimation(_animation, _text, _image);
+	        button.StartAnimation(_animation, _text, _image, _spriteRender);
         }
     }
 }

--- a/Source/Engine/AGS.Engine/UI/Controls/Textbox/AGSTextboxComponent.cs
+++ b/Source/Engine/AGS.Engine/UI/Controls/Textbox/AGSTextboxComponent.cs
@@ -12,7 +12,7 @@ namespace AGS.Engine
         private IImageComponent _imageComponent;
         private IVisibleComponent _visibleComponent;
         private IDrawableInfoComponent _drawableComponent;
-        private IAnimationComponent _animationComponent;
+        private ISpriteRenderComponent _spriteComponent;
         private IUIEvents _uiEvents;        
         private IInObjectTreeComponent _tree;
         private IHasRoomComponent _room;
@@ -78,15 +78,15 @@ namespace AGS.Engine
             _withCaret.Pivot = new PointF(0f, 0f);
             _withCaret.TextBackgroundVisible = false;
 
-            entity.Bind<IAnimationComponent>(c =>
+            entity.Bind<ISpriteRenderComponent>(c =>
             {
-                c.PropertyChanged += onAnimationPropertyChanged;
-                _animationComponent = c;
+                c.PropertyChanged += onSpritePropertyChanged;
+                _spriteComponent = c;
                 updateBorder();
             }, c =>
             {
-                c.PropertyChanged -= onAnimationPropertyChanged;
-                _animationComponent = null;
+                c.PropertyChanged -= onSpritePropertyChanged;
+                _spriteComponent = null;
                 updateBorder();
             });
 
@@ -108,15 +108,15 @@ namespace AGS.Engine
             updateWatermark();
         }
 
-        private void onAnimationPropertyChanged(object sender, PropertyChangedEventArgs e)
+        private void onSpritePropertyChanged(object sender, PropertyChangedEventArgs e)
         {
-            if (e.PropertyName != nameof(IAnimationComponent.Border)) return;
+            if (e.PropertyName != nameof(ISpriteRenderComponent.Border)) return;
             updateBorder();
         }
 
         private void updateBorder()
         {
-            _withCaret.Border = _animationComponent?.Border;
+            _withCaret.Border = _spriteComponent?.Border;
         }
 
         public override void AfterInit()

--- a/Source/Engine/AGS.Engine/UI/DebugControls/DebugView/GameDebugTree.cs
+++ b/Source/Engine/AGS.Engine/UI/DebugControls/DebugView/GameDebugTree.cs
@@ -16,7 +16,7 @@ namespace AGS.Engine
         private IPanel _treePanel, _scrollingPanel, _parent;
         private ITextBox _searchBox;
 
-        private IAnimationComponent _lastSelectedObject;
+        private ISpriteRenderComponent _lastSelectedObject;
         private IVisibleComponent _lastSelectedMaskVisible;
         private IImageComponent _lastSelectedMaskImage;
         private IBorderStyle _lastObjectBorder;
@@ -113,19 +113,19 @@ namespace AGS.Engine
         { 
             var obj = node.Properties.Entities.GetValue(Fields.Entity);
             _inspector.Inspector.Show(obj);
-            var animation = obj.GetComponent<IAnimationComponent>();
+            var spriteRender = obj.GetComponent<ISpriteRenderComponent>();
             var visibleComponent = obj.GetComponent<IVisibleComponent>();
             var image = obj.GetComponent<IImageComponent>();
-            if (animation != null)
+            if (spriteRender != null)
             {
-                _lastSelectedObject = animation;
+                _lastSelectedObject = spriteRender;
                 IBorderStyle border = null;          
-                border = animation.Border;
+                border = spriteRender.Border;
                 _lastObjectBorder = border;
                 IBorderStyle hoverBorder = AGSBorders.Gradient(new FourCorners<Color>(Colors.Yellow, Colors.Yellow.WithAlpha(150),
                                                                                       Colors.Yellow.WithAlpha(150), Colors.Yellow), 1, true);
-                if (border == null) animation.Border = hoverBorder;
-                else animation.Border = AGSBorders.Multiple(border, hoverBorder);
+                if (border == null) spriteRender.Border = hoverBorder;
+                else spriteRender.Border = AGSBorders.Multiple(border, hoverBorder);
             }
             if (visibleComponent != null)
             {

--- a/Source/Engine/AGS.Engine/UI/Skin/Skins/AGSColoredSkin.cs
+++ b/Source/Engine/AGS.Engine/UI/Skin/Skins/AGSColoredSkin.cs
@@ -26,7 +26,7 @@ namespace AGS.Engine
 
         public PointF DefaultItemSize = new PointF(100f, 50f);
 
-        private ButtonAnimation getAnimation(IAnimationComponent container, ButtonAnimation animation)
+        private ButtonAnimation getAnimation(ISpriteRenderComponent container, ButtonAnimation animation)
         {
             if (animation.Border == null || container == null || container.Border == null) return animation;
             ButtonAnimation newAnimation = new ButtonAnimation(AGSBorders.Multiple(container.Border, animation.Border),
@@ -41,21 +41,21 @@ namespace AGS.Engine
 
             skin.AddRule(entity => entity.GetComponent<IButtonComponent>() != null, entity => 
             {
-                var animContainer = entity.GetComponent<IAnimationComponent>();
+                var spriteRender = entity.GetComponent<ISpriteRenderComponent>();
                 var button = entity.GetComponent<IButtonComponent>();
-                button.IdleAnimation = getAnimation(animContainer, ButtonIdleAnimation);
-                button.HoverAnimation = getAnimation(animContainer, ButtonHoverAnimation);
-                button.PushedAnimation = getAnimation(animContainer, ButtonPushedAnimation);
+                button.IdleAnimation = getAnimation(spriteRender, ButtonIdleAnimation);
+                button.HoverAnimation = getAnimation(spriteRender, ButtonHoverAnimation);
+                button.PushedAnimation = getAnimation(spriteRender, ButtonPushedAnimation);
             });
 
             skin.AddRule(entity => entity.GetComponent<ICheckboxComponent>() != null, entity => 
             {
-                var animContainer = entity.GetComponent<IAnimationComponent>();
+                var spriteRender = entity.GetComponent<ISpriteRenderComponent>();
                 var button = entity.GetComponent<ICheckboxComponent>();
-                button.NotCheckedAnimation = getAnimation(animContainer, CheckboxNotCheckedAnimation);
-                button.CheckedAnimation = getAnimation(animContainer, CheckboxCheckedAnimation);
-                button.HoverCheckedAnimation = getAnimation(animContainer, CheckboxHoverCheckedAnimation);
-                button.HoverNotCheckedAnimation = getAnimation(animContainer, CheckboxHoverNotCheckedAnimation);
+                button.NotCheckedAnimation = getAnimation(spriteRender, CheckboxNotCheckedAnimation);
+                button.CheckedAnimation = getAnimation(spriteRender, CheckboxCheckedAnimation);
+                button.HoverCheckedAnimation = getAnimation(spriteRender, CheckboxHoverCheckedAnimation);
+                button.HoverNotCheckedAnimation = getAnimation(spriteRender, CheckboxHoverNotCheckedAnimation);
             });
 
             skin.AddRule(entity =>
@@ -76,8 +76,8 @@ namespace AGS.Engine
             {
                 var imageComponent = entity.GetComponent<IImageComponent>();
                 if (imageComponent != null) imageComponent.Tint = DialogBoxColor;
-                var animationComponent = entity.GetComponent<IAnimationComponent>();
-                if (animationComponent != null) animationComponent.Border = DialogBoxBorder;
+                var spriteRender = entity.GetComponent<ISpriteRenderComponent>();
+                if (spriteRender != null) spriteRender.Border = DialogBoxBorder;
             });
 
             skin.AddRule(entity =>
@@ -110,11 +110,11 @@ namespace AGS.Engine
 
             skin.AddRule<ITextBoxComponent>(entity =>
             {
-                var animationComponent = entity.GetComponent<IAnimationComponent>();
+                var spriteComponent = entity.GetComponent<ISpriteRenderComponent>();
                 var image = entity.GetComponent<IImageComponent>();
-                if (animationComponent == null) return;
+                if (spriteComponent == null) return;
                 image.Tint = TextBoxBackColor;
-                animationComponent.Border = TextBoxBorderStyle;
+                spriteComponent.Border = TextBoxBorderStyle;
             });
 
             return skin;


### PR DESCRIPTION
For #206.

This adds ISpriteRenderComponent interface and its AGSSpriteRenderComponent implementation.
SpriteRenderer is supposed to become a focal point of image-based objects (and eventually implement rendering itself), having its properties updated by others, such as AnimationComponent.
Moved Border and DebugDrawPivot properties from Animation to SpriteRender component.
Had to add OnNextFrame event to IAnimation to let AnimationComponent know when to update renderer.


**NOTE 1:**
When I was about to create this PR, the doubts came to me, and I thought that I might be doing something wrong.
Initially, I proposed this component as a medium between renderer and 2D image-based components, but since we decided there will be IRenderer interface, that components could may implement themselves (e.g. mentioned in #207), does that make SpriteComponent redundant? Because, to think of it, AnimationComponent and ImageComponent (especially latter one) can implement IRenderer too.
I am mostly wondering if ImageComponent and SpriteRenderComponent are essentially duplicating each other, or not.

**NOTE 2:**
Current implementation is a first try. There were few things I had doubts about in technical sense (added TODO comments for these).

First of all, template generation failed for me for some reason, introducing unexpected changes to generated classes. I will try to investigate again, but for now I just implemented the necessary changes by hand.

Secondly, since AnimationComponent is not rendered directly, but has to update SpriteRenderComp., I had to somehow let it know that animation frame changes, so added new event to IAnimation. The first tests in DemoGame show that rendering works, but there were couple of possible glitches, and I am not sure whether my code covered all possible cases when animation may be updated.
