### PR TITLE
Implement ISpriteProvider in ImageComponent and decouple it from animation

### DIFF
--- a/Source/AGS.API/Graphics/IImageComponent.cs
+++ b/Source/AGS.API/Graphics/IImageComponent.cs
@@ -61,7 +61,6 @@ namespace AGS.API
     /// <summary>
     /// A component which allows setting an image to the entity.
     /// </summary>
-    [RequiredComponent(typeof(IAnimationComponent))]
     [RequiredComponent(typeof(IScaleComponent))]
     public interface IImageComponent : IHasImage, IComponent
     {

--- a/Source/AGS.API/Objects/Collisions/IBoundingBoxComponent.cs
+++ b/Source/AGS.API/Objects/Collisions/IBoundingBoxComponent.cs
@@ -6,7 +6,6 @@
     /// </summary>
     [RequiredComponent(typeof(IModelMatrixComponent))]
     [RequiredComponent(typeof(IImageComponent))]
-    [RequiredComponent(typeof(IAnimationComponent))]
     [RequiredComponent(typeof(IDrawableInfoComponent))]
     [RequiredComponent(typeof(IHasRoomComponent))]
     [RequiredComponent(typeof(ICropSelfComponent), false)]

--- a/Source/AGS.API/Objects/Collisions/IColliderComponent.cs
+++ b/Source/AGS.API/Objects/Collisions/IColliderComponent.cs
@@ -6,7 +6,6 @@
     /// if the <see cref="IPixelPerfectComponent"/> exists and enabled.
     /// </summary>
 	[RequiredComponent(typeof(IDrawableInfoComponent))]
-	[RequiredComponent(typeof(IAnimationComponent))]
     [RequiredComponent(typeof(IScaleComponent))]
     [RequiredComponent(typeof(IPixelPerfectComponent))]
 	public interface IColliderComponent : IComponent

--- a/Source/AGS.API/Objects/IModelMatrixComponent.cs
+++ b/Source/AGS.API/Objects/IModelMatrixComponent.cs
@@ -21,7 +21,6 @@
     /// </summary>
     [RequiredComponent(typeof(IScaleComponent))]
     [RequiredComponent(typeof(ITranslateComponent))]
-    [RequiredComponent(typeof(IAnimationComponent))]
     [RequiredComponent(typeof(IRotateComponent))]
     [RequiredComponent(typeof(IImageComponent))]
     [RequiredComponent(typeof(IHasRoomComponent))]

--- a/Source/AGS.API/Objects/IScaleComponent.cs
+++ b/Source/AGS.API/Objects/IScaleComponent.cs
@@ -96,7 +96,6 @@ namespace AGS.API
     /// Allows scaling (changing the size of) an entity.
     /// </summary>
     [RequiredComponent(typeof(IImageComponent))]
-    [RequiredComponent(typeof(IAnimationComponent), false)]
     public interface IScaleComponent : IScale, IComponent
     {
     }

--- a/Source/Demo/DemoQuest/GUI/TopBar.cs
+++ b/Source/Demo/DemoQuest/GUI/TopBar.cs
@@ -104,7 +104,7 @@ namespace DemoGame
 			if (_lastInventoryItem != null)
 			{
 				_inventoryItemIcon.Image = _lastInventoryItem.CursorGraphics.Image;
-				_inventoryItemIcon.Animation.Sprite.Pivot = new PointF (0.5f, 0.5f);
+				_inventoryItemIcon.CurrentSprite.Pivot = new PointF (0.5f, 0.5f);
 				_inventoryItemIcon.ScaleTo(15f, 15f);
 			}
 			_inventoryItemIcon.Visible = (_lastInventoryItem != null);

--- a/Source/Engine/AGS.Engine/Graphics/Logic/AGSRendererLoop.cs
+++ b/Source/Engine/AGS.Engine/Graphics/Logic/AGSRendererLoop.cs
@@ -224,13 +224,13 @@ namespace AGS.Engine
         //todo: duplicate code with AGSDisplayList
 		private IImageRenderer getImageRenderer(IObject obj)
 		{
-			return obj.CustomRenderer ?? getAnimationRenderer(obj) ?? _renderer;
+			return obj.CustomRenderer ?? getSpriteRenderer(obj) ?? _renderer;
 		}
 
-		private IImageRenderer getAnimationRenderer(IObject obj)
+		private IImageRenderer getSpriteRenderer(IObject obj)
 		{
-			if (obj.Animation == null) return null;
-			return obj.Animation.Sprite.CustomRenderer;
+			if (obj.CurrentSprite == null) return null;
+			return obj.CurrentSprite.CustomRenderer;
 		}
 	}
 }

--- a/Source/Engine/AGS.Engine/Graphics/Logic/AGSRendererLoop.cs
+++ b/Source/Engine/AGS.Engine/Graphics/Logic/AGSRendererLoop.cs
@@ -229,8 +229,7 @@ namespace AGS.Engine
 
 		private IImageRenderer getSpriteRenderer(IObject obj)
 		{
-			if (obj.CurrentSprite == null) return null;
-			return obj.CurrentSprite.CustomRenderer;
+			return obj?.CurrentSprite?.CustomRenderer;
 		}
 	}
 }

--- a/Source/Engine/AGS.Engine/Graphics/Logic/DisplayList/AGSDisplayList.cs
+++ b/Source/Engine/AGS.Engine/Graphics/Logic/DisplayList/AGSDisplayList.cs
@@ -312,13 +312,13 @@ namespace AGS.Engine
         //todo: duplicate code with AGSRendererLoop
 		private IImageRenderer getImageRenderer(IObject obj)
 		{
-			return obj.CustomRenderer ?? getAnimationRenderer(obj) ?? _renderer;
+			return obj.CustomRenderer ?? getSpriteRenderer(obj) ?? _renderer;
 		}
 
-		private IImageRenderer getAnimationRenderer(IObject obj)
+		private IImageRenderer getSpriteRenderer(IObject obj)
 		{
-			if (obj.Animation == null) return null;
-			return obj.Animation.Sprite.CustomRenderer;
+			if (obj.CurrentSprite == null) return null;
+			return obj.CurrentSprite.CustomRenderer;
 		}
 
         private void onUiChanged(AGSHashSetChangedEventArgs<IObject> args)

--- a/Source/Engine/AGS.Engine/Graphics/Logic/DisplayList/AGSDisplayList.cs
+++ b/Source/Engine/AGS.Engine/Graphics/Logic/DisplayList/AGSDisplayList.cs
@@ -317,8 +317,7 @@ namespace AGS.Engine
 
 		private IImageRenderer getSpriteRenderer(IObject obj)
 		{
-			if (obj.CurrentSprite == null) return null;
-			return obj.CurrentSprite.CustomRenderer;
+			return obj?.CurrentSprite?.CustomRenderer;
 		}
 
         private void onUiChanged(AGSHashSetChangedEventArgs<IObject> args)

--- a/Source/Engine/AGS.Engine/Graphics/Logic/RenderOrderSelector.cs
+++ b/Source/Engine/AGS.Engine/Graphics/Logic/RenderOrderSelector.cs
@@ -116,14 +116,14 @@ namespace AGS.Engine
 
 		private float getZ(IObject obj)
 		{
-            float zAnimation = obj.Animation == null || obj.Animation.Sprite == null ? 0f : obj.Animation.Sprite.Z;
-			return obj.Z + zAnimation;
+            float zSprite = obj.CurrentSprite == null ? 0f : obj.CurrentSprite.Z;
+			return obj.Z + zSprite;
 		}
 
         private float getX(IObject obj)
         {
-            float xAnimation = obj.Animation == null || obj.Animation.Sprite == null ? 0f : obj.Animation.Sprite.X;
-            return obj.X + xAnimation;
+            float xSprite = obj.CurrentSprite == null ? 0f : obj.CurrentSprite.X;
+            return obj.X + xSprite;
         }
 	}
 }

--- a/Source/Engine/AGS.Engine/Objects/Collisions/AGSCollider.cs
+++ b/Source/Engine/AGS.Engine/Objects/Collisions/AGSCollider.cs
@@ -6,7 +6,7 @@ namespace AGS.Engine
 	{
 		private IGameState _state;
 		private IDrawableInfoComponent _drawableInfo;
-		private IAnimationComponent _obj;
+		private ISpriteRenderComponent _obj;
         private IScale _scale;
         private IPixelPerfectCollidable _pixelPerfect;
         private IEntity _entity;
@@ -22,7 +22,7 @@ namespace AGS.Engine
 			base.Init(entity);
             _entity = entity;
             entity.Bind<IDrawableInfoComponent>(c => _drawableInfo = c, _ => _drawableInfo = null);
-            entity.Bind<IAnimationComponent>(c => _obj = c, _ => _obj = null);
+            entity.Bind<ISpriteRenderComponent>(c => _obj = c, _ => _obj = null);
             entity.Bind<IScaleComponent>(c => _scale = c, _ => _scale = null);
             entity.Bind<IPixelPerfectComponent>(c => _pixelPerfect = c, _ => _pixelPerfect = null);
             entity.Bind<IBoundingBoxComponent>(c => _boundingBox = c, _ => _boundingBox = null);
@@ -77,8 +77,8 @@ namespace AGS.Engine
 			else
 			{
                 var obj = _obj;
-                float objScaleX = obj == null ? 1f : obj.Animation.Sprite.ScaleX;
-                float objScaleY = obj == null ? 1f : obj.Animation.Sprite.ScaleY;
+                float objScaleX = obj == null ? 1f : obj.CurrentSprite.ScaleX;
+                float objScaleY = obj == null ? 1f : obj.CurrentSprite.ScaleY;
                 var scale = _scale;
                 float scaleX = scale == null ? 1f : scale.ScaleX;
                 float scaleY = scale == null ? 1f : scale.ScaleY;

--- a/Source/Engine/AGS.Engine/Objects/Collisions/AGSPixelPerfectCollidable.cs
+++ b/Source/Engine/AGS.Engine/Objects/Collisions/AGSPixelPerfectCollidable.cs
@@ -66,9 +66,10 @@ namespace AGS.Engine
 
         private void updateProvider()
         {
-            if (_spriteRender.SpriteProvider != null && _spriteRender.SpriteProvider is IAnimationComponent)
+            if (_spriteRender.SpriteProvider != null &&
+                _spriteRender.SpriteProvider is IAnimationComponent animation)
             {
-                _animation = _spriteRender.SpriteProvider as IAnimationComponent;
+                _animation = animation;
                 _animation.OnAnimationStarted.Subscribe(refreshPixelPerfect);
             }
             else

--- a/Source/Engine/AGS.Engine/Objects/Collisions/AGSPixelPerfectCollidable.cs
+++ b/Source/Engine/AGS.Engine/Objects/Collisions/AGSPixelPerfectCollidable.cs
@@ -1,45 +1,83 @@
-﻿using AGS.API;
+﻿using System.ComponentModel;
+using AGS.API;
 
 namespace AGS.Engine
 {
     public class AGSPixelPerfectCollidable : IPixelPerfectCollidable
     {
+        private ISpriteRenderComponent _spriteRender;
         private IAnimationComponent _animation;
         private bool _pixelPerfect;
 
-        public AGSPixelPerfectCollidable(IAnimationComponent animation)
+        public AGSPixelPerfectCollidable(ISpriteRenderComponent spriteRender)
         {
-            _animation = animation;
-            _animation.OnAnimationStarted.Subscribe(refreshPixelPerfect);
+            _spriteRender = spriteRender;
+            _spriteRender.PropertyChanged += onProviderChanged;
+            updateProvider();
         }
 
         public IArea PixelPerfectHitTestArea
         {
             get
             {
-                if (_animation.Animation == null || _animation.Animation.Sprite == null) return null;
-                return _animation.Animation.Sprite.PixelPerfectHitTestArea;
+                return _spriteRender?.CurrentSprite?.PixelPerfectHitTestArea;
             }
         }        
 
         public void PixelPerfect(bool pixelPerfect)
         {
             _pixelPerfect = pixelPerfect;
-            if (_animation.Animation == null || _animation.Animation.Frames == null) return;
-            foreach (var frame in _animation.Animation.Frames)
+            if (_animation != null)
             {
-                frame.Sprite.PixelPerfect(pixelPerfect);
+                // Special case if the sprite provider is animation, where we need to update all frames
+                // TODO: may there be a way to implement an abstract approach here to let do the same
+                // kind of update to any hypothetical custom component?
+                // Or, event better, do not have the pixel-perfect switch in the sprites at all.
+                if (_animation.Animation == null || _animation.Animation.Frames == null)
+                    return;
+                foreach (var frame in _animation.Animation.Frames)
+                {
+                    frame.Sprite.PixelPerfect(pixelPerfect);
+                }
+            }
+            else if (_spriteRender.CurrentSprite != null)
+            {
+                _spriteRender.CurrentSprite.PixelPerfect(pixelPerfect);
             }
         }
 
         public void Dispose()
         {
-            _animation.OnAnimationStarted.Unsubscribe(refreshPixelPerfect);
+            if (_animation != null)
+                _animation.OnAnimationStarted.Unsubscribe(refreshPixelPerfect);
+            _spriteRender.PropertyChanged -= onProviderChanged;
         }
 
         private void refreshPixelPerfect()
         {
             PixelPerfect(_pixelPerfect);
+        }
+
+        private void onProviderChanged(object sender, PropertyChangedEventArgs e)
+        {
+            if (e.PropertyName == nameof(ISpriteRenderComponent.SpriteProvider))
+                updateProvider();
+        }
+
+        private void updateProvider()
+        {
+            if (_spriteRender.SpriteProvider != null && _spriteRender.SpriteProvider is IAnimationComponent)
+            {
+                _animation = _spriteRender.SpriteProvider as IAnimationComponent;
+                _animation.OnAnimationStarted.Subscribe(refreshPixelPerfect);
+            }
+            else
+            {
+                if (_animation != null)
+                    _animation.OnAnimationStarted.Unsubscribe(refreshPixelPerfect);
+                _animation = null;
+            }
+            refreshPixelPerfect();
         }
     }
 }

--- a/Source/Engine/AGS.Engine/Objects/Collisions/AGSPixelPerfectComponent.cs
+++ b/Source/Engine/AGS.Engine/Objects/Collisions/AGSPixelPerfectComponent.cs
@@ -17,11 +17,10 @@ namespace AGS.Engine
         {
             base.Init(entity);
 
-            entity.Bind<IAnimationComponent>(c =>
+            entity.Bind<ISpriteRenderComponent>(c =>
             {
-                IAnimationComponent animation = entity.GetComponent<IAnimationComponent>();
-                TypedParameter animationParam = new TypedParameter(typeof(IAnimationComponent), animation);
-                _pixelPerfect = _resolver.Container.Resolve<IPixelPerfectCollidable>(animationParam);
+                TypedParameter spriteParam = new TypedParameter(typeof(ISpriteRenderComponent), c);
+                _pixelPerfect = _resolver.Container.Resolve<IPixelPerfectCollidable>(spriteParam);
             }, c => { c.Dispose(); _pixelPerfect = null; });
         }
 

--- a/Source/Engine/AGS.Engine/Objects/Scale/AGSScaleComponent.cs
+++ b/Source/Engine/AGS.Engine/Objects/Scale/AGSScaleComponent.cs
@@ -10,7 +10,7 @@ namespace AGS.Engine
     {
         private IScale _scale;
         private readonly Resolver _resolver;
-        private IAnimationComponent _animation;
+        private ISpriteRenderComponent _spriteRender;
 
         public AGSScaleComponent(Resolver resolver)
         {
@@ -30,7 +30,7 @@ namespace AGS.Engine
                 _scale = null;
                 c.PropertyChanged -= onScalePropertyChanged;
             });
-            entity.Bind<IAnimationComponent>(c => _animation = c, _ => _animation = null);
+            entity.Bind<ISpriteRenderComponent>(c => _spriteRender = c, _ => _spriteRender = null);
         }
 
         [Property(Category = "Size")]
@@ -94,9 +94,7 @@ namespace AGS.Engine
 
         private ISprite getSprite()
         {
-            var animation = _animation;
-            if (animation == null || animation.Animation == null) return null;
-            return animation.Animation.Sprite;
+            return _spriteRender?.CurrentSprite;
         }
 
         private void onScalePropertyChanged(object sender, PropertyChangedEventArgs args)

--- a/Source/Engine/AGS.Engine/Rooms/RoomSizeProviders/RoomLimitsFromBackground.cs
+++ b/Source/Engine/AGS.Engine/Rooms/RoomSizeProviders/RoomLimitsFromBackground.cs
@@ -7,7 +7,7 @@ namespace AGS.Engine
         public RectangleF ProvideRoomLimits(IRoom room)
         {
             if (room.Background == null) return RoomCustomLimits.MaxLimits;
-            ISprite sprite = room.Background.Animation.Sprite;
+            ISprite sprite = room.Background.CurrentSprite;
             return new RectangleF(0f, 0f, sprite.Width, sprite.Height);
         }
     }

--- a/Source/Engine/AGS.Engine/Serialization/Contracts/ContractObject.cs
+++ b/Source/Engine/AGS.Engine/Serialization/Contracts/ContractObject.cs
@@ -114,10 +114,8 @@ namespace AGS.Engine
             obj.Angle = Angle;
             obj.Tint = Color.FromHexa(Tint);
 
-            obj.PixelPerfect(IsPixelPerfect);            
+            obj.PixelPerfect(IsPixelPerfect);
             AnimationComponent.ToItem(context, obj);
-            if (obj.Animation.Frames.Count > 0)
-                obj.Scale = obj.Scale;
             obj.RenderLayer = RenderLayer.ToItem(context);
 			if (WalkPoint != null)
 			{

--- a/Source/Engine/AGS.Engine/Serialization/ContractsFactory.cs
+++ b/Source/Engine/AGS.Engine/Serialization/ContractsFactory.cs
@@ -99,7 +99,9 @@ namespace AGS.Engine
 			{
 				if (x.GetTypeInfo().IsAssignableFrom(y.GetTypeInfo()))
 					return 1;
-				return -1;
+                else if (y.GetTypeInfo().IsAssignableFrom(x.GetTypeInfo()))
+				    return -1;
+                return 0;
 			}
 			#endregion
 

--- a/Source/Engine/AGS.Engine/UI/Text/Dialogs/AGSDialogLayout.cs
+++ b/Source/Engine/AGS.Engine/UI/Text/Dialogs/AGSDialogLayout.cs
@@ -40,7 +40,7 @@ namespace AGS.Engine
 				dialogGraphics.Image = new EmptyImage (_game.Settings.VirtualResolution.Width, y);
 			}
 
-			dialogGraphics.Animation.Sprite.ScaleTo(_game.Settings.VirtualResolution.Width, y);
+			dialogGraphics.CurrentSprite.ScaleTo(_game.Settings.VirtualResolution.Width, y);
 		}
 
 		#endregion

--- a/Source/Tests/Engine/Graphics/Logic/RenderOrderSelectorTests.cs
+++ b/Source/Tests/Engine/Graphics/Logic/RenderOrderSelectorTests.cs
@@ -151,9 +151,6 @@ namespace Tests
 			Mock<ISprite> sprite = new Mock<ISprite> ();
 			sprite.Setup(s => s.Z).Returns(spriteZ);
 
-			Mock<IAnimation> animation = new Mock<IAnimation> ();
-			animation.Setup(a => a.Sprite).Returns(sprite.Object);
-
 			Mock<ITreeNode<IObject>> tree = new Mock<ITreeNode<IObject>> ();
 			tree.Setup(t => t.Parent).Returns(parent);
 
@@ -167,7 +164,7 @@ namespace Tests
 
 			Mock<IObject> obj = new Mock<IObject> ();
 			obj.Setup(o => o.Z).Returns(z);
-			obj.Setup(o => o.Animation).Returns(animation.Object);
+			obj.Setup(o => o.CurrentSprite).Returns(sprite.Object);
 			obj.Setup(o => o.TreeNode).Returns(tree.Object);
 			obj.Setup(o => o.RenderLayer).Returns(layer);
             obj.Setup(o => o.Properties).Returns(new AGSCustomProperties());


### PR DESCRIPTION
Currently ImageComponent requires AnimationComponent to work, and stores an image as a single-frame animation. Animation is being used everywhere where program needs to read current object's look.

This PR decouples ImageComponent from Animation, makes it store image in a simple Sprite wrapper and implement ISpriteProvider interface. After this ImageComponent may be used without AnimationComponent.

Replaces number of AnimationComponent references in the code with the SpriteRenderComponent and its CurrentSprite (except places where having animation was a necessary condition).

This also serves as a "proof of concept" for custom independent sprite providers.