### PR TITLE
Remove "adventure layer" from IObject

### DIFF
--- a/Source/AGS.API/ComponentsFramework/IEntity.cs
+++ b/Source/AGS.API/ComponentsFramework/IEntity.cs
@@ -15,6 +15,19 @@
         /// </summary>
         /// <value>The identifier.</value>
 		string ID { get; }
-	}
+
+        /// <summary>
+        /// A human-readable name.
+        /// This string could be used to display entity's name to players.
+        /// </summary>
+        /// <value>The name.</value>
+        string DisplayName { get; set; }
+
+        /// <summary>
+        /// Returns a human-readable name of an entity, either taken from DisplayName or composed from other properties.
+        /// </summary>
+        /// <returns>The name.</returns>
+        string GetFriendlyName();
+    }
 }
 

--- a/Source/AGS.API/Game/Factories/IObjectFactory.cs
+++ b/Source/AGS.API/Game/Factories/IObjectFactory.cs
@@ -12,9 +12,17 @@ namespace AGS.API
         /// </summary>
         /// <returns>The object.</returns>
         /// <param name="id">A unique identifier for the object (this has to be globally unique across all entities).</param>
+		IObject GetObject(string id);
+
+        /// <summary>
+        /// Creates a new object with IHotspotComponent, which supports have reaction to character interactions (command verbs).
+        /// TODO: invent a new type name for this. It can be IAdventureObject or something simple like IHotspot.
+        /// </summary>
+        /// <returns>The object.</returns>
+        /// <param name="id">A unique identifier for the object (this has to be globally unique across all entities).</param>
         /// <param name="sayWhenLook">An optional list of things that the player will say (one after the other) when looking on the object.</param>
         /// <param name="sayWhenInteract">An optional list of things that the player will say (one after the other) when interacting with the object.</param>
-		IObject GetObject(string id, string[] sayWhenLook = null, string[] sayWhenInteract = null);
+        IObject GetAdventureObject(string id, string[] sayWhenLook = null, string[] sayWhenInteract = null);
 
         /// <summary>
         /// Creates a new character

--- a/Source/AGS.API/Objects/Characters/ICharacter.cs
+++ b/Source/AGS.API/Objects/Characters/ICharacter.cs
@@ -5,8 +5,8 @@
     /// to depict adventure game characters.
     /// </summary>
 	public interface ICharacter : IObject, ISayComponent, IWalkComponent, IFaceDirectionComponent, 
-		IOutfitComponent, IInventoryComponent, IFollowComponent
-	{
+		IOutfitComponent, IInventoryComponent, IFollowComponent, IHotspotComponent
+    {
 	}
 }
 

--- a/Source/AGS.API/Objects/IHotspotComponent.cs
+++ b/Source/AGS.API/Objects/IHotspotComponent.cs
@@ -19,6 +19,13 @@
         /// <seealso cref="IApproachStyle"/>
         /// <value>The walk point.</value>
 		PointF? WalkPoint { get; set; }
+
+        /// <summary>
+        /// Gets or sets whether the hotspot name should be shown by a hotspot label when hovering over the entity.
+        /// <seealso cref="IEntity.DisplayName"/>
+        /// </summary>
+        /// <value><c>true</c> if display hotspot's name; otherwise, <c>false</c>.</value>
+		bool DisplayHotspot { get; set; }
 	}
 }
 

--- a/Source/AGS.API/Objects/IHotspotComponent.cs
+++ b/Source/AGS.API/Objects/IHotspotComponent.cs
@@ -19,12 +19,6 @@
         /// <seealso cref="IApproachStyle"/>
         /// <value>The walk point.</value>
 		PointF? WalkPoint { get; set; }
-
-        /// <summary>
-        /// Gets or sets the hotspot text that can be showed by a hotspot label when hovering over the entity.
-        /// </summary>
-        /// <value>The hotspot.</value>
-		string Hotspot { get; set; }
 	}
 }
 

--- a/Source/AGS.API/Objects/IObject.cs
+++ b/Source/AGS.API/Objects/IObject.cs
@@ -5,7 +5,7 @@
     /// to depict all adventure game objects. Both characters and UI controls are also objects (with additional components).
     /// </summary>
 	public interface IObject : IEntity, IHasRoomComponent, ISpriteRenderComponent, IAnimationComponent, IInObjectTreeComponent, IColliderComponent, 
-		IVisibleComponent, IEnabledComponent, ICustomPropertiesComponent, IDrawableInfoComponent, IHotspotComponent, 
+		IVisibleComponent, IEnabledComponent, ICustomPropertiesComponent, IDrawableInfoComponent, 
         IShaderComponent, ITranslateComponent, IImageComponent, IScaleComponent, IRotateComponent, 
         IPixelPerfectComponent, IHasModelMatrix, IModelMatrixComponent, IBoundingBoxComponent
 	{

--- a/Source/Demo/DemoQuest/Characters/Beman.cs
+++ b/Source/Demo/DemoQuest/Characters/Beman.cs
@@ -51,7 +51,7 @@ namespace DemoGame
 			Characters.RandomAnimationDelay(speakAnimation.Up);
 
             _character.StartAnimation (_character.Outfit[AGSOutfit.Idle].Down);
-			_character.Hotspot = "Beman";
+			_character.DisplayName = "Beman";
 			_character.PixelPerfect(true);
 
 			Characters.Beman = _character;

--- a/Source/Demo/DemoQuest/Characters/Cris.cs
+++ b/Source/Demo/DemoQuest/Characters/Cris.cs
@@ -46,7 +46,7 @@ namespace DemoGame
             emitter.Assign(_character.Outfit[AGSOutfit.Walk], 1, 5);
 
             _character.StartAnimation (_character.Outfit[AGSOutfit.Idle].Down);
-			_character.Hotspot = "Cris";
+			_character.DisplayName = "Cris";
 			_character.PixelPerfect(true);
 
 			Characters.Cris = _character;

--- a/Source/Demo/DemoQuest/DefaultInteractions.cs
+++ b/Source/Demo/DemoQuest/DefaultInteractions.cs
@@ -60,14 +60,14 @@ namespace DemoGame
 
 		private async Task onInventoryCombination(InventoryCombinationEventArgs args)
 		{
-			if (string.IsNullOrEmpty(args.ActiveItem.Graphics.Hotspot) ||
-			    string.IsNullOrEmpty(args.PassiveItem.Graphics.Hotspot))
+			if (string.IsNullOrEmpty(args.ActiveItem.Graphics.DisplayName) ||
+			    string.IsNullOrEmpty(args.PassiveItem.Graphics.DisplayName))
 			{
 				await _game.State.Player.SayAsync("I don't think these two items go together.");
 				return;
 			}
 
-			await _game.State.Player.SayAsync($"Use {args.ActiveItem.Graphics.Hotspot} on {args.PassiveItem.Graphics.Hotspot}? I don't get it...");
+			await _game.State.Player.SayAsync($"Use {args.ActiveItem.Graphics.DisplayName} on {args.PassiveItem.Graphics.DisplayName}? I don't get it...");
 		}
 
         private Task sayAsync(string text)

--- a/Source/Demo/DemoQuest/Rooms/BrokenCurbStreet.cs
+++ b/Source/Demo/DemoQuest/Rooms/BrokenCurbStreet.cs
@@ -63,7 +63,7 @@ namespace DemoGame
 			_room.Objects.Add(wallHotspot);
 
 			IObject panel = factory.Object.GetObject("Panel");
-			panel.Hotspot = "Panel";
+			panel.DisplayName = "Panel";
 			IAnimation panelAnimation = await factory.Graphics.LoadAnimationFromFolderAsync(_baseFolder + "Panel");
 			Characters.RandomAnimationDelay(panelAnimation);
 			panel.StartAnimation(panelAnimation);

--- a/Source/Demo/DemoQuest/Rooms/BrokenCurbStreet.cs
+++ b/Source/Demo/DemoQuest/Rooms/BrokenCurbStreet.cs
@@ -62,7 +62,7 @@ namespace DemoGame
 			_room.Objects.Add(await factory.Object.GetHotspotAsync(_baseFolder + "slimeHotspot.png", "Slime"));
 			_room.Objects.Add(wallHotspot);
 
-			IObject panel = factory.Object.GetObject("Panel");
+			IObject panel = factory.Object.GetAdventureObject("Panel");
 			panel.DisplayName = "Panel";
 			IAnimation panelAnimation = await factory.Graphics.LoadAnimationFromFolderAsync(_baseFolder + "Panel");
 			Characters.RandomAnimationDelay(panelAnimation);
@@ -70,7 +70,7 @@ namespace DemoGame
 			panel.X = 195;
 			panel.Y = 145;
 			panel.Z = 110;
-            panel.Interactions.OnInteract(AGSInteractions.INTERACT).Subscribe(_ => panel.Animation.State.IsPaused = !panel.Animation.State.IsPaused);
+            panel.GetComponent<IHotspotComponent>().Interactions.OnInteract(AGSInteractions.INTERACT).Subscribe(_ => panel.Animation.State.IsPaused = !panel.Animation.State.IsPaused);
 			_room.Objects.Add(panel);
 
 			subscribeEvents();

--- a/Source/Demo/DemoQuest/Rooms/DarsStreet.cs
+++ b/Source/Demo/DemoQuest/Rooms/DarsStreet.cs
@@ -43,7 +43,7 @@ namespace DemoGame
 			IObject windowHotspot = await factory.Object.GetHotspotAsync (_baseFolder + "windowHotspot.png", "Window");
 			doorHotspot.Z = buildingHotspot.Z - 1;
 			windowHotspot.Z = buildingHotspot.Z - 1;
-            windowHotspot.Interactions.OnInteract(AGSInteractions.LOOK).SubscribeToAsync(lookOnWindow);
+            windowHotspot.GetComponent<IHotspotComponent>().Interactions.OnInteract(AGSInteractions.LOOK).SubscribeToAsync(lookOnWindow);
 
 			_room.Objects.Add(await factory.Object.GetHotspotAsync(_baseFolder + "aztecBuildingHotspot.png", "Aztec Building"));
 			_room.Objects.Add(buildingHotspot);

--- a/Source/Demo/DemoQuest/Rooms/EmptyStreet.cs
+++ b/Source/Demo/DemoQuest/Rooms/EmptyStreet.cs
@@ -54,7 +54,7 @@ namespace DemoGame
 			_bottle.WalkPoint = bottleHotspot.WalkPoint;
 			_bottle.X = 185f;
 			_bottle.Y = 85f;
-			_bottle.Hotspot = "Bottle";
+			_bottle.DisplayName = "Bottle";
 			_room.Objects.Add(_bottle);
 
 			subscribeEvents();

--- a/Source/Demo/DemoQuest/Rooms/EmptyStreet.cs
+++ b/Source/Demo/DemoQuest/Rooms/EmptyStreet.cs
@@ -44,14 +44,14 @@ namespace DemoGame
             factory.Room.CreateScaleArea(_room.Areas[1], 0.75f, 0.90f);
 
 			IObject bottleHotspot = await factory.Object.GetHotspotAsync(_baseFolder + "BottleHotspot.png", "Bottle");
-			bottleHotspot.WalkPoint = new PointF (140f, 50f);
+			bottleHotspot.GetComponent<IHotspotComponent>().WalkPoint = new PointF (140f, 50f);
 			_room.Objects.Add(await factory.Object.GetHotspotAsync (_baseFolder + "CurbHotspot.png", "Curb"));
 			_room.Objects.Add(bottleHotspot);
 			_room.Objects.Add(await factory.Object.GetHotspotAsync (_baseFolder + "GapHotspot.png", "Gap", new[]{"It's a gap!", "I wonder what's in there!"}));
 
-			_bottle = factory.Object.GetObject(_bottleId);
+			_bottle = factory.Object.GetAdventureObject(_bottleId);
 			_bottle.Image = await factory.Graphics.LoadImageAsync(_baseFolder + "bottle.bmp", loadConfig: loadConfig);
-			_bottle.WalkPoint = bottleHotspot.WalkPoint;
+			_bottle.GetComponent<IHotspotComponent>().WalkPoint = bottleHotspot.GetComponent<IHotspotComponent>().WalkPoint;
 			_bottle.X = 185f;
 			_bottle.Y = 85f;
 			_bottle.DisplayName = "Bottle";
@@ -76,7 +76,7 @@ namespace DemoGame
 			_room.Edges.Right.OnEdgeCrossed.Subscribe(onRightEdgeCrossed);
 			_room.Events.OnBeforeFadeIn.Subscribe(onBeforeFadeIn);
 			_room.Events.OnAfterFadeIn.Subscribe(onAfterFadeIn);
-            _bottle?.Interactions.OnInteract(AGSInteractions.INTERACT).SubscribeToAsync(onBottleInteract);
+            _bottle?.GetComponent<IHotspotComponent>().Interactions.OnInteract(AGSInteractions.INTERACT).SubscribeToAsync(onBottleInteract);
 		}
 
 		private async Task onBottleInteract(ObjectEventArgs args)

--- a/Source/Engine/AGS.Engine.Desktop/Drawing/DesktopBitmap.cs
+++ b/Source/Engine/AGS.Engine.Desktop/Drawing/DesktopBitmap.cs
@@ -145,7 +145,7 @@ namespace AGS.Engine.Desktop
 			IObject debugDraw = null;
 			if (debugDrawColor != null)
 			{
-				debugDraw = factory.Object.GetObject(id ?? path ?? "Mask Drawable");
+				debugDraw = factory.Object.GetAdventureObject(id ?? path ?? "Mask Drawable");
                 debugDraw.Image = factory.Graphics.LoadImage(new DesktopBitmap(debugMask, _graphics), null, path);
 				debugDraw.Pivot = new AGS.API.PointF ();
 			}

--- a/Source/Engine/AGS.Engine/ComponentsFramework/AGSEntity.cs
+++ b/Source/Engine/AGS.Engine/ComponentsFramework/AGSEntity.cs
@@ -44,6 +44,10 @@ namespace AGS.Engine
 
         public string ID { get; private set; }
 
+        public string DisplayName { get; set; }
+
+        public string GetFriendlyName() { return DisplayName ?? ID; }
+
         public IBlockingEvent OnComponentsInitialized { get; private set; }
 
         public IBlockingEvent<AGSListChangedEventArgs<IComponent>> OnComponentsChanged { get; private set; }

--- a/Source/Engine/AGS.Engine/ComponentsFramework/Templates/AGSButton.generated.cs
+++ b/Source/Engine/AGS.Engine/ComponentsFramework/Templates/AGSButton.generated.cs
@@ -355,12 +355,6 @@ namespace AGS.Engine
             set { _hotspotComponent.WalkPoint = value; } 
         }
 
-        public String Hotspot 
-        {  
-            get { return _hotspotComponent.Hotspot; }  
-            set { _hotspotComponent.Hotspot = value; } 
-        }
-
         #endregion
 
         #region IShaderComponent implementation

--- a/Source/Engine/AGS.Engine/ComponentsFramework/Templates/AGSButton.generated.cs
+++ b/Source/Engine/AGS.Engine/ComponentsFramework/Templates/AGSButton.generated.cs
@@ -25,7 +25,6 @@ namespace AGS.Engine
         private IEnabledComponent _enabledComponent;
         private ICustomPropertiesComponent _customPropertiesComponent;
         private IDrawableInfoComponent _drawableInfoComponent;
-        private IHotspotComponent _hotspotComponent;
         private IShaderComponent _shaderComponent;
         private ITranslateComponent _translateComponent;
         private IImageComponent _imageComponent;
@@ -61,8 +60,6 @@ namespace AGS.Engine
             Bind<ICustomPropertiesComponent>(c => _customPropertiesComponent = c, _ => {});            
             _drawableInfoComponent = AddComponent<IDrawableInfoComponent>();
             Bind<IDrawableInfoComponent>(c => _drawableInfoComponent = c, _ => {});            
-            _hotspotComponent = AddComponent<IHotspotComponent>();
-            Bind<IHotspotComponent>(c => _hotspotComponent = c, _ => {});            
             _shaderComponent = AddComponent<IShaderComponent>();
             Bind<IShaderComponent>(c => _shaderComponent = c, _ => {});            
             _translateComponent = AddComponent<ITranslateComponent>();
@@ -338,21 +335,6 @@ namespace AGS.Engine
         {  
             get { return _drawableInfoComponent.IgnoreScalingArea; }  
             set { _drawableInfoComponent.IgnoreScalingArea = value; } 
-        }
-
-        #endregion
-
-        #region IHotspotComponent implementation
-
-        public IInteractions Interactions 
-        {  
-            get { return _hotspotComponent.Interactions; } 
-        }
-
-        public Nullable<PointF> WalkPoint 
-        {  
-            get { return _hotspotComponent.WalkPoint; }  
-            set { _hotspotComponent.WalkPoint = value; } 
         }
 
         #endregion

--- a/Source/Engine/AGS.Engine/ComponentsFramework/Templates/AGSCharacter.generated.cs
+++ b/Source/Engine/AGS.Engine/ComponentsFramework/Templates/AGSCharacter.generated.cs
@@ -289,6 +289,12 @@ namespace AGS.Engine
             set { _hotspotComponent.WalkPoint = value; } 
         }
 
+        public bool DisplayHotspot 
+        {  
+            get { return _hotspotComponent.DisplayHotspot; }  
+            set { _hotspotComponent.DisplayHotspot = value; } 
+        }
+
         #endregion
 
         #region IShaderComponent implementation

--- a/Source/Engine/AGS.Engine/ComponentsFramework/Templates/AGSCharacter.generated.cs
+++ b/Source/Engine/AGS.Engine/ComponentsFramework/Templates/AGSCharacter.generated.cs
@@ -289,12 +289,6 @@ namespace AGS.Engine
             set { _hotspotComponent.WalkPoint = value; } 
         }
 
-        public String Hotspot 
-        {  
-            get { return _hotspotComponent.Hotspot; }  
-            set { _hotspotComponent.Hotspot = value; } 
-        }
-
         #endregion
 
         #region IShaderComponent implementation

--- a/Source/Engine/AGS.Engine/ComponentsFramework/Templates/AGSCheckbox.generated.cs
+++ b/Source/Engine/AGS.Engine/ComponentsFramework/Templates/AGSCheckbox.generated.cs
@@ -352,12 +352,6 @@ namespace AGS.Engine
             set { _hotspotComponent.WalkPoint = value; } 
         }
 
-        public String Hotspot 
-        {  
-            get { return _hotspotComponent.Hotspot; }  
-            set { _hotspotComponent.Hotspot = value; } 
-        }
-
         #endregion
 
         #region IShaderComponent implementation

--- a/Source/Engine/AGS.Engine/ComponentsFramework/Templates/AGSCheckbox.generated.cs
+++ b/Source/Engine/AGS.Engine/ComponentsFramework/Templates/AGSCheckbox.generated.cs
@@ -25,7 +25,6 @@ namespace AGS.Engine
         private IEnabledComponent _enabledComponent;
         private ICustomPropertiesComponent _customPropertiesComponent;
         private IDrawableInfoComponent _drawableInfoComponent;
-        private IHotspotComponent _hotspotComponent;
         private IShaderComponent _shaderComponent;
         private ITranslateComponent _translateComponent;
         private IImageComponent _imageComponent;
@@ -60,8 +59,6 @@ namespace AGS.Engine
             Bind<ICustomPropertiesComponent>(c => _customPropertiesComponent = c, _ => {});            
             _drawableInfoComponent = AddComponent<IDrawableInfoComponent>();
             Bind<IDrawableInfoComponent>(c => _drawableInfoComponent = c, _ => {});            
-            _hotspotComponent = AddComponent<IHotspotComponent>();
-            Bind<IHotspotComponent>(c => _hotspotComponent = c, _ => {});            
             _shaderComponent = AddComponent<IShaderComponent>();
             Bind<IShaderComponent>(c => _shaderComponent = c, _ => {});            
             _translateComponent = AddComponent<ITranslateComponent>();
@@ -335,21 +332,6 @@ namespace AGS.Engine
         {  
             get { return _drawableInfoComponent.IgnoreScalingArea; }  
             set { _drawableInfoComponent.IgnoreScalingArea = value; } 
-        }
-
-        #endregion
-
-        #region IHotspotComponent implementation
-
-        public IInteractions Interactions 
-        {  
-            get { return _hotspotComponent.Interactions; } 
-        }
-
-        public Nullable<PointF> WalkPoint 
-        {  
-            get { return _hotspotComponent.WalkPoint; }  
-            set { _hotspotComponent.WalkPoint = value; } 
         }
 
         #endregion

--- a/Source/Engine/AGS.Engine/ComponentsFramework/Templates/AGSComboBox.generated.cs
+++ b/Source/Engine/AGS.Engine/ComponentsFramework/Templates/AGSComboBox.generated.cs
@@ -26,7 +26,6 @@ namespace AGS.Engine
         private IEnabledComponent _enabledComponent;
         private ICustomPropertiesComponent _customPropertiesComponent;
         private IDrawableInfoComponent _drawableInfoComponent;
-        private IHotspotComponent _hotspotComponent;
         private IShaderComponent _shaderComponent;
         private ITranslateComponent _translateComponent;
         private IImageComponent _imageComponent;
@@ -62,8 +61,6 @@ namespace AGS.Engine
             Bind<ICustomPropertiesComponent>(c => _customPropertiesComponent = c, _ => {});            
             _drawableInfoComponent = AddComponent<IDrawableInfoComponent>();
             Bind<IDrawableInfoComponent>(c => _drawableInfoComponent = c, _ => {});            
-            _hotspotComponent = AddComponent<IHotspotComponent>();
-            Bind<IHotspotComponent>(c => _hotspotComponent = c, _ => {});            
             _shaderComponent = AddComponent<IShaderComponent>();
             Bind<IShaderComponent>(c => _shaderComponent = c, _ => {});            
             _translateComponent = AddComponent<ITranslateComponent>();
@@ -374,21 +371,6 @@ namespace AGS.Engine
         {  
             get { return _drawableInfoComponent.IgnoreScalingArea; }  
             set { _drawableInfoComponent.IgnoreScalingArea = value; } 
-        }
-
-        #endregion
-
-        #region IHotspotComponent implementation
-
-        public IInteractions Interactions 
-        {  
-            get { return _hotspotComponent.Interactions; } 
-        }
-
-        public Nullable<PointF> WalkPoint 
-        {  
-            get { return _hotspotComponent.WalkPoint; }  
-            set { _hotspotComponent.WalkPoint = value; } 
         }
 
         #endregion

--- a/Source/Engine/AGS.Engine/ComponentsFramework/Templates/AGSComboBox.generated.cs
+++ b/Source/Engine/AGS.Engine/ComponentsFramework/Templates/AGSComboBox.generated.cs
@@ -391,12 +391,6 @@ namespace AGS.Engine
             set { _hotspotComponent.WalkPoint = value; } 
         }
 
-        public String Hotspot 
-        {  
-            get { return _hotspotComponent.Hotspot; }  
-            set { _hotspotComponent.Hotspot = value; } 
-        }
-
         #endregion
 
         #region IShaderComponent implementation

--- a/Source/Engine/AGS.Engine/ComponentsFramework/Templates/AGSInventoryWindow.generated.cs
+++ b/Source/Engine/AGS.Engine/ComponentsFramework/Templates/AGSInventoryWindow.generated.cs
@@ -352,12 +352,6 @@ namespace AGS.Engine
             set { _hotspotComponent.WalkPoint = value; } 
         }
 
-        public String Hotspot 
-        {  
-            get { return _hotspotComponent.Hotspot; }  
-            set { _hotspotComponent.Hotspot = value; } 
-        }
-
         #endregion
 
         #region IShaderComponent implementation

--- a/Source/Engine/AGS.Engine/ComponentsFramework/Templates/AGSInventoryWindow.generated.cs
+++ b/Source/Engine/AGS.Engine/ComponentsFramework/Templates/AGSInventoryWindow.generated.cs
@@ -25,7 +25,6 @@ namespace AGS.Engine
         private IEnabledComponent _enabledComponent;
         private ICustomPropertiesComponent _customPropertiesComponent;
         private IDrawableInfoComponent _drawableInfoComponent;
-        private IHotspotComponent _hotspotComponent;
         private IShaderComponent _shaderComponent;
         private ITranslateComponent _translateComponent;
         private IImageComponent _imageComponent;
@@ -60,8 +59,6 @@ namespace AGS.Engine
             Bind<ICustomPropertiesComponent>(c => _customPropertiesComponent = c, _ => {});            
             _drawableInfoComponent = AddComponent<IDrawableInfoComponent>();
             Bind<IDrawableInfoComponent>(c => _drawableInfoComponent = c, _ => {});            
-            _hotspotComponent = AddComponent<IHotspotComponent>();
-            Bind<IHotspotComponent>(c => _hotspotComponent = c, _ => {});            
             _shaderComponent = AddComponent<IShaderComponent>();
             Bind<IShaderComponent>(c => _shaderComponent = c, _ => {});            
             _translateComponent = AddComponent<ITranslateComponent>();
@@ -335,21 +332,6 @@ namespace AGS.Engine
         {  
             get { return _drawableInfoComponent.IgnoreScalingArea; }  
             set { _drawableInfoComponent.IgnoreScalingArea = value; } 
-        }
-
-        #endregion
-
-        #region IHotspotComponent implementation
-
-        public IInteractions Interactions 
-        {  
-            get { return _hotspotComponent.Interactions; } 
-        }
-
-        public Nullable<PointF> WalkPoint 
-        {  
-            get { return _hotspotComponent.WalkPoint; }  
-            set { _hotspotComponent.WalkPoint = value; } 
         }
 
         #endregion

--- a/Source/Engine/AGS.Engine/ComponentsFramework/Templates/AGSLabel.generated.cs
+++ b/Source/Engine/AGS.Engine/ComponentsFramework/Templates/AGSLabel.generated.cs
@@ -396,12 +396,6 @@ namespace AGS.Engine
             set { _hotspotComponent.WalkPoint = value; } 
         }
 
-        public String Hotspot 
-        {  
-            get { return _hotspotComponent.Hotspot; }  
-            set { _hotspotComponent.Hotspot = value; } 
-        }
-
         #endregion
 
         #region IShaderComponent implementation

--- a/Source/Engine/AGS.Engine/ComponentsFramework/Templates/AGSLabel.generated.cs
+++ b/Source/Engine/AGS.Engine/ComponentsFramework/Templates/AGSLabel.generated.cs
@@ -26,7 +26,6 @@ namespace AGS.Engine
         private IEnabledComponent _enabledComponent;
         private ICustomPropertiesComponent _customPropertiesComponent;
         private IDrawableInfoComponent _drawableInfoComponent;
-        private IHotspotComponent _hotspotComponent;
         private IShaderComponent _shaderComponent;
         private ITranslateComponent _translateComponent;
         private IImageComponent _imageComponent;
@@ -62,8 +61,6 @@ namespace AGS.Engine
             Bind<ICustomPropertiesComponent>(c => _customPropertiesComponent = c, _ => {});            
             _drawableInfoComponent = AddComponent<IDrawableInfoComponent>();
             Bind<IDrawableInfoComponent>(c => _drawableInfoComponent = c, _ => {});            
-            _hotspotComponent = AddComponent<IHotspotComponent>();
-            Bind<IHotspotComponent>(c => _hotspotComponent = c, _ => {});            
             _shaderComponent = AddComponent<IShaderComponent>();
             Bind<IShaderComponent>(c => _shaderComponent = c, _ => {});            
             _translateComponent = AddComponent<ITranslateComponent>();
@@ -379,21 +376,6 @@ namespace AGS.Engine
         {  
             get { return _drawableInfoComponent.IgnoreScalingArea; }  
             set { _drawableInfoComponent.IgnoreScalingArea = value; } 
-        }
-
-        #endregion
-
-        #region IHotspotComponent implementation
-
-        public IInteractions Interactions 
-        {  
-            get { return _hotspotComponent.Interactions; } 
-        }
-
-        public Nullable<PointF> WalkPoint 
-        {  
-            get { return _hotspotComponent.WalkPoint; }  
-            set { _hotspotComponent.WalkPoint = value; } 
         }
 
         #endregion

--- a/Source/Engine/AGS.Engine/ComponentsFramework/Templates/AGSObject.generated.cs
+++ b/Source/Engine/AGS.Engine/ComponentsFramework/Templates/AGSObject.generated.cs
@@ -279,12 +279,6 @@ namespace AGS.Engine
             set { _hotspotComponent.WalkPoint = value; } 
         }
 
-        public String Hotspot 
-        {  
-            get { return _hotspotComponent.Hotspot; }  
-            set { _hotspotComponent.Hotspot = value; } 
-        }
-
         #endregion
 
         #region IShaderComponent implementation

--- a/Source/Engine/AGS.Engine/ComponentsFramework/Templates/AGSObject.generated.cs
+++ b/Source/Engine/AGS.Engine/ComponentsFramework/Templates/AGSObject.generated.cs
@@ -23,7 +23,6 @@ namespace AGS.Engine
         private IEnabledComponent _enabledComponent;
         private ICustomPropertiesComponent _customPropertiesComponent;
         private IDrawableInfoComponent _drawableInfoComponent;
-        private IHotspotComponent _hotspotComponent;
         private IShaderComponent _shaderComponent;
         private ITranslateComponent _translateComponent;
         private IImageComponent _imageComponent;
@@ -53,8 +52,6 @@ namespace AGS.Engine
             Bind<ICustomPropertiesComponent>(c => _customPropertiesComponent = c, _ => {});            
             _drawableInfoComponent = AddComponent<IDrawableInfoComponent>();
             Bind<IDrawableInfoComponent>(c => _drawableInfoComponent = c, _ => {});            
-            _hotspotComponent = AddComponent<IHotspotComponent>();
-            Bind<IHotspotComponent>(c => _hotspotComponent = c, _ => {});            
             _shaderComponent = AddComponent<IShaderComponent>();
             Bind<IShaderComponent>(c => _shaderComponent = c, _ => {});            
             _translateComponent = AddComponent<ITranslateComponent>();
@@ -262,21 +259,6 @@ namespace AGS.Engine
         {  
             get { return _drawableInfoComponent.IgnoreScalingArea; }  
             set { _drawableInfoComponent.IgnoreScalingArea = value; } 
-        }
-
-        #endregion
-
-        #region IHotspotComponent implementation
-
-        public IInteractions Interactions 
-        {  
-            get { return _hotspotComponent.Interactions; } 
-        }
-
-        public Nullable<PointF> WalkPoint 
-        {  
-            get { return _hotspotComponent.WalkPoint; }  
-            set { _hotspotComponent.WalkPoint = value; } 
         }
 
         #endregion

--- a/Source/Engine/AGS.Engine/ComponentsFramework/Templates/AGSPanel.generated.cs
+++ b/Source/Engine/AGS.Engine/ComponentsFramework/Templates/AGSPanel.generated.cs
@@ -349,12 +349,6 @@ namespace AGS.Engine
             set { _hotspotComponent.WalkPoint = value; } 
         }
 
-        public String Hotspot 
-        {  
-            get { return _hotspotComponent.Hotspot; }  
-            set { _hotspotComponent.Hotspot = value; } 
-        }
-
         #endregion
 
         #region IShaderComponent implementation

--- a/Source/Engine/AGS.Engine/ComponentsFramework/Templates/AGSPanel.generated.cs
+++ b/Source/Engine/AGS.Engine/ComponentsFramework/Templates/AGSPanel.generated.cs
@@ -25,7 +25,6 @@ namespace AGS.Engine
         private IEnabledComponent _enabledComponent;
         private ICustomPropertiesComponent _customPropertiesComponent;
         private IDrawableInfoComponent _drawableInfoComponent;
-        private IHotspotComponent _hotspotComponent;
         private IShaderComponent _shaderComponent;
         private ITranslateComponent _translateComponent;
         private IImageComponent _imageComponent;
@@ -59,8 +58,6 @@ namespace AGS.Engine
             Bind<ICustomPropertiesComponent>(c => _customPropertiesComponent = c, _ => {});            
             _drawableInfoComponent = AddComponent<IDrawableInfoComponent>();
             Bind<IDrawableInfoComponent>(c => _drawableInfoComponent = c, _ => {});            
-            _hotspotComponent = AddComponent<IHotspotComponent>();
-            Bind<IHotspotComponent>(c => _hotspotComponent = c, _ => {});            
             _shaderComponent = AddComponent<IShaderComponent>();
             Bind<IShaderComponent>(c => _shaderComponent = c, _ => {});            
             _translateComponent = AddComponent<ITranslateComponent>();
@@ -332,21 +329,6 @@ namespace AGS.Engine
         {  
             get { return _drawableInfoComponent.IgnoreScalingArea; }  
             set { _drawableInfoComponent.IgnoreScalingArea = value; } 
-        }
-
-        #endregion
-
-        #region IHotspotComponent implementation
-
-        public IInteractions Interactions 
-        {  
-            get { return _hotspotComponent.Interactions; } 
-        }
-
-        public Nullable<PointF> WalkPoint 
-        {  
-            get { return _hotspotComponent.WalkPoint; }  
-            set { _hotspotComponent.WalkPoint = value; } 
         }
 
         #endregion

--- a/Source/Engine/AGS.Engine/ComponentsFramework/Templates/AGSSlider.generated.cs
+++ b/Source/Engine/AGS.Engine/ComponentsFramework/Templates/AGSSlider.generated.cs
@@ -26,7 +26,6 @@ namespace AGS.Engine
         private IEnabledComponent _enabledComponent;
         private ICustomPropertiesComponent _customPropertiesComponent;
         private IDrawableInfoComponent _drawableInfoComponent;
-        private IHotspotComponent _hotspotComponent;
         private IShaderComponent _shaderComponent;
         private ITranslateComponent _translateComponent;
         private IImageComponent _imageComponent;
@@ -62,8 +61,6 @@ namespace AGS.Engine
             Bind<ICustomPropertiesComponent>(c => _customPropertiesComponent = c, _ => {});            
             _drawableInfoComponent = AddComponent<IDrawableInfoComponent>();
             Bind<IDrawableInfoComponent>(c => _drawableInfoComponent = c, _ => {});            
-            _hotspotComponent = AddComponent<IHotspotComponent>();
-            Bind<IHotspotComponent>(c => _hotspotComponent = c, _ => {});            
             _shaderComponent = AddComponent<IShaderComponent>();
             Bind<IShaderComponent>(c => _shaderComponent = c, _ => {});            
             _translateComponent = AddComponent<ITranslateComponent>();
@@ -397,21 +394,6 @@ namespace AGS.Engine
         {  
             get { return _drawableInfoComponent.IgnoreScalingArea; }  
             set { _drawableInfoComponent.IgnoreScalingArea = value; } 
-        }
-
-        #endregion
-
-        #region IHotspotComponent implementation
-
-        public IInteractions Interactions 
-        {  
-            get { return _hotspotComponent.Interactions; } 
-        }
-
-        public Nullable<PointF> WalkPoint 
-        {  
-            get { return _hotspotComponent.WalkPoint; }  
-            set { _hotspotComponent.WalkPoint = value; } 
         }
 
         #endregion

--- a/Source/Engine/AGS.Engine/ComponentsFramework/Templates/AGSSlider.generated.cs
+++ b/Source/Engine/AGS.Engine/ComponentsFramework/Templates/AGSSlider.generated.cs
@@ -414,12 +414,6 @@ namespace AGS.Engine
             set { _hotspotComponent.WalkPoint = value; } 
         }
 
-        public String Hotspot 
-        {  
-            get { return _hotspotComponent.Hotspot; }  
-            set { _hotspotComponent.Hotspot = value; } 
-        }
-
         #endregion
 
         #region IShaderComponent implementation

--- a/Source/Engine/AGS.Engine/ComponentsFramework/Templates/AGSTextbox.generated.cs
+++ b/Source/Engine/AGS.Engine/ComponentsFramework/Templates/AGSTextbox.generated.cs
@@ -355,12 +355,6 @@ namespace AGS.Engine
             set { _hotspotComponent.WalkPoint = value; } 
         }
 
-        public String Hotspot 
-        {  
-            get { return _hotspotComponent.Hotspot; }  
-            set { _hotspotComponent.Hotspot = value; } 
-        }
-
         #endregion
 
         #region IShaderComponent implementation

--- a/Source/Engine/AGS.Engine/ComponentsFramework/Templates/AGSTextbox.generated.cs
+++ b/Source/Engine/AGS.Engine/ComponentsFramework/Templates/AGSTextbox.generated.cs
@@ -25,7 +25,6 @@ namespace AGS.Engine
         private IEnabledComponent _enabledComponent;
         private ICustomPropertiesComponent _customPropertiesComponent;
         private IDrawableInfoComponent _drawableInfoComponent;
-        private IHotspotComponent _hotspotComponent;
         private IShaderComponent _shaderComponent;
         private ITranslateComponent _translateComponent;
         private IImageComponent _imageComponent;
@@ -61,8 +60,6 @@ namespace AGS.Engine
             Bind<ICustomPropertiesComponent>(c => _customPropertiesComponent = c, _ => {});            
             _drawableInfoComponent = AddComponent<IDrawableInfoComponent>();
             Bind<IDrawableInfoComponent>(c => _drawableInfoComponent = c, _ => {});            
-            _hotspotComponent = AddComponent<IHotspotComponent>();
-            Bind<IHotspotComponent>(c => _hotspotComponent = c, _ => {});            
             _shaderComponent = AddComponent<IShaderComponent>();
             Bind<IShaderComponent>(c => _shaderComponent = c, _ => {});            
             _translateComponent = AddComponent<ITranslateComponent>();
@@ -338,21 +335,6 @@ namespace AGS.Engine
         {  
             get { return _drawableInfoComponent.IgnoreScalingArea; }  
             set { _drawableInfoComponent.IgnoreScalingArea = value; } 
-        }
-
-        #endregion
-
-        #region IHotspotComponent implementation
-
-        public IInteractions Interactions 
-        {  
-            get { return _hotspotComponent.Interactions; } 
-        }
-
-        public Nullable<PointF> WalkPoint 
-        {  
-            get { return _hotspotComponent.WalkPoint; }  
-            set { _hotspotComponent.WalkPoint = value; } 
         }
 
         #endregion

--- a/Source/Engine/AGS.Engine/Game/Factories/AGSInventoryFactory.cs
+++ b/Source/Engine/AGS.Engine/Game/Factories/AGSInventoryFactory.cs
@@ -80,7 +80,7 @@ namespace AGS.Engine
 			graphics.IgnoreViewport = true;
 			graphics.IgnoreScalingArea = true;
 			graphics.Pivot = new PointF (0.5f, 0.5f);
-			graphics.Hotspot = hotspot;
+			graphics.DisplayName = hotspot;
 
 			IObject cursor = _object.GetObject ($"{hotspot ?? ""}(inventory item cursor)");
 			cursor.Image = cursorImage;

--- a/Source/Engine/AGS.Engine/Game/Factories/AGSInventoryFactory.cs
+++ b/Source/Engine/AGS.Engine/Game/Factories/AGSInventoryFactory.cs
@@ -74,7 +74,7 @@ namespace AGS.Engine
 
 		private IInventoryItem getInventoryItem(string hotspot, IImage graphicsImage, IImage cursorImage, bool playerStartsWithItem = false)
 		{
-			IObject graphics = _object.GetObject ($"{hotspot ?? ""}(inventory item)");
+			IObject graphics = _object.GetAdventureObject ($"{hotspot ?? ""}(inventory item)");
 			graphics.Image = graphicsImage;
 			graphics.RenderLayer = AGSLayers.UI;
 			graphics.IgnoreViewport = true;

--- a/Source/Engine/AGS.Engine/Game/Factories/AGSObjectFactory.cs
+++ b/Source/Engine/AGS.Engine/Game/Factories/AGSObjectFactory.cs
@@ -74,7 +74,7 @@ namespace AGS.Engine
 		{
 			mask.DebugDraw.PixelPerfect (true);
             mask.DebugDraw.Enabled = true;
-			mask.DebugDraw.Hotspot = hotspot;
+			mask.DebugDraw.DisplayName = hotspot;
 			mask.DebugDraw.Opacity = 0;
 			mask.DebugDraw.Z = mask.MinY;
 

--- a/Source/Engine/AGS.Engine/Input/Schemes/RotatingCursorScheme.cs
+++ b/Source/Engine/AGS.Engine/Input/Schemes/RotatingCursorScheme.cs
@@ -104,8 +104,9 @@ namespace AGS.Engine
 		{
 			string mode = CurrentMode;
             IObject hotspot = hitTest.ObjectAtMousePosition;
+            IHotspotComponent hotComp = hotspot?.GetComponent<IHotspotComponent>();
 
-			if (_game.Input.Cursor != _inventoryCursor.Animation)
+            if (_game.Input.Cursor != _inventoryCursor.Animation)
 			{
 				if (hotspot != null && hotspot.Room == null) 
 				{
@@ -138,19 +139,19 @@ namespace AGS.Engine
 					_handlingClick = true;
 					try
 					{
-						if (hotspot == null) return;
+						if (hotComp == null) return;
 
 						if (mode == LOOK_MODE)
 						{
-                            await hotspot.Interactions.OnInteract(AGSInteractions.LOOK).InvokeAsync(new ObjectEventArgs (hotspot));
+                            await hotComp.Interactions.OnInteract(AGSInteractions.LOOK).InvokeAsync(new ObjectEventArgs (hotspot));
 						}
 						else if (mode == INTERACT_MODE)
 						{
-                            await hotspot.Interactions.OnInteract(AGSInteractions.INTERACT).InvokeAsync(new ObjectEventArgs (hotspot));
+                            await hotComp.Interactions.OnInteract(AGSInteractions.INTERACT).InvokeAsync(new ObjectEventArgs (hotspot));
 						}
 						else
 						{
-                            await hotspot.Interactions.OnInteract(mode).InvokeAsync(new ObjectEventArgs (hotspot));
+                            await hotComp.Interactions.OnInteract(mode).InvokeAsync(new ObjectEventArgs (hotspot));
 						}
 					}
 					finally
@@ -159,7 +160,7 @@ namespace AGS.Engine
 					}
 				}
 			}
-			else if (hotspot != null)
+			else if (hotComp != null)
 			{
 				if (hotspot.Room == null)
 				{
@@ -174,7 +175,7 @@ namespace AGS.Engine
 					return;
 				}
 
-                await hotspot.Interactions.OnInventoryInteract(AGSInteractions.INTERACT).InvokeAsync(new InventoryInteractEventArgs(hotspot,
+                await hotComp.Interactions.OnInventoryInteract(AGSInteractions.INTERACT).InvokeAsync(new InventoryInteractEventArgs(hotspot,
 					state.Player.Inventory.ActiveItem));
 			}
 		}

--- a/Source/Engine/AGS.Engine/Inventory/AGSInventoryItem.cs
+++ b/Source/Engine/AGS.Engine/Inventory/AGSInventoryItem.cs
@@ -25,7 +25,7 @@ namespace AGS.Engine
 
 		public override string ToString()
 		{
-			return $"Inventory Item: {Graphics.ID ?? Graphics.Hotspot ?? Graphics.ToString()}";
+			return $"Inventory Item: {Graphics.GetFriendlyName() ?? Graphics.ToString()}";
 		}
 	}
 }

--- a/Source/Engine/AGS.Engine/Objects/AGSHotspotComponent.cs
+++ b/Source/Engine/AGS.Engine/Objects/AGSHotspotComponent.cs
@@ -21,12 +21,15 @@ namespace AGS.Engine
 			TypedParameter defaults = new TypedParameter (typeof(IInteractions), _gameEvents.DefaultInteractions);
 			TypedParameter objParam = new TypedParameter (typeof(IObject), entity as IObject);
 			Interactions = _resolver.Container.Resolve<IInteractions>(defaults, objParam);
+            DisplayHotspot = true;
 		}
 
         [Property(Browsable = false)]
 		public IInteractions Interactions { get; private set; }
 
 		public PointF? WalkPoint { get; set; }
+
+		public bool DisplayHotspot { get; set; }
 	}
 }
 

--- a/Source/Engine/AGS.Engine/Objects/AGSHotspotComponent.cs
+++ b/Source/Engine/AGS.Engine/Objects/AGSHotspotComponent.cs
@@ -27,8 +27,6 @@ namespace AGS.Engine
 		public IInteractions Interactions { get; private set; }
 
 		public PointF? WalkPoint { get; set; }
-
-		public string Hotspot { get; set; }
 	}
 }
 

--- a/Source/Engine/AGS.Engine/Player/Approach/AGSApproachComponent.cs
+++ b/Source/Engine/AGS.Engine/Player/Approach/AGSApproachComponent.cs
@@ -28,6 +28,8 @@ namespace AGS.Engine
             ApproachHotspots approachStyle = getApproachStyle(verb);
             var faceDirection = _faceDirection;
             var walk = _walk;
+            var hotspot = obj.GetComponent<IHotspotComponent>();
+            var walkPt = hotspot?.WalkPoint;
             switch (approachStyle)
             {
                 case ApproachHotspots.NeverWalk:
@@ -36,15 +38,15 @@ namespace AGS.Engine
                     if (faceDirection != null) await faceDirection.FaceDirectionAsync(obj);
                     break;
                 case ApproachHotspots.WalkIfHaveWalkPoint:
-                    if (obj.WalkPoint == null && faceDirection != null) await faceDirection.FaceDirectionAsync(obj);
+                    if (walkPt == null && faceDirection != null) await faceDirection.FaceDirectionAsync(obj);
                     else
                     {
-                        if (walk != null && !await walk.WalkAsync(new AGSLocation(obj.WalkPoint.Value))) return false;
+                        if (walk != null && !await walk.WalkAsync(new AGSLocation(walkPt.Value))) return false;
                         if (faceDirection != null) await faceDirection.FaceDirectionAsync(obj);
                     }
                     break;
                 case ApproachHotspots.AlwaysWalk:
-                    PointF? walkPoint = obj.WalkPoint ?? obj.CenterPoint ?? obj.Location.XY;
+                    PointF? walkPoint = walkPt ?? obj.CenterPoint ?? obj.Location.XY;
                     if (walk != null && !await walk.WalkAsync(new AGSLocation(walkPoint.Value))) return false;
                     if (faceDirection != null) await _faceDirection.FaceDirectionAsync(obj);
                     break;

--- a/Source/Engine/AGS.Engine/Serialization/Contracts/ContractObject.cs
+++ b/Source/Engine/AGS.Engine/Serialization/Contracts/ContractObject.cs
@@ -32,7 +32,7 @@ namespace AGS.Engine
 		public bool Enabled { get; set; }
 
 		[ProtoMember(5)]
-		public string Hotspot { get; set; }
+		public string DisplayName { get; set; }
 
 		[ProtoMember(6)]
 		public bool IgnoreViewport { get; set; }
@@ -123,7 +123,7 @@ namespace AGS.Engine
 			}
             obj.Properties.CopyFrom(Properties.ToItem(context));
 			obj.Enabled = Enabled;
-			obj.Hotspot = Hotspot;
+			obj.DisplayName = DisplayName;
 			obj.IgnoreViewport = IgnoreViewport;
 			obj.IgnoreScalingArea = IgnoreScalingArea;
 			obj.Visible = Visible;
@@ -151,7 +151,7 @@ namespace AGS.Engine
 			}
 			Enabled = item.UnderlyingEnabled;
 			Visible = item.UnderlyingVisible;
-			Hotspot = item.Hotspot;
+            DisplayName = item.DisplayName;
 			IgnoreViewport = item.IgnoreViewport;
 			IgnoreScalingArea = item.IgnoreScalingArea;
 			if (Parent == null && item.TreeNode != null && item.TreeNode.Parent != null)

--- a/Source/Engine/AGS.Engine/Serialization/Contracts/ContractObject.cs
+++ b/Source/Engine/AGS.Engine/Serialization/Contracts/ContractObject.cs
@@ -23,67 +23,64 @@ namespace AGS.Engine
 		public IContract<IRenderLayer> RenderLayer { get; set; }
 
 		[ProtoMember(2)]
-		public Tuple<float, float> WalkPoint { get; set; }
-
-		[ProtoMember(3)]
 		public IContract<ICustomProperties> Properties { get; set; }
 
-		[ProtoMember(4)]
+		[ProtoMember(3)]
 		public bool Enabled { get; set; }
 
-		[ProtoMember(5)]
+		[ProtoMember(4)]
 		public string DisplayName { get; set; }
 
-		[ProtoMember(6)]
+		[ProtoMember(5)]
 		public bool IgnoreViewport { get; set; }
 
-		[ProtoMember(7)]
+		[ProtoMember(6)]
 		public bool IgnoreScalingArea { get; set; }
 
-		[ProtoMember(8)]
+		[ProtoMember(7)]
 		public ContractAnimationComponent AnimationComponent { get; set; }
 
-		[ProtoMember(9, AsReference = true)]
+		[ProtoMember(8, AsReference = true)]
 		public IContract<IObject> Parent { get; set; }
 
-		[ProtoMember(10)]
+		[ProtoMember(9)]
 		public string ID { get; set; }
 
-		[ProtoMember(11)]
+		[ProtoMember(10)]
 		public bool Visible { get; set; }
 
-        [ProtoMember(12)]
+        [ProtoMember(11)]
         public float InitialWidth { get; set; }
 
-        [ProtoMember(13)]
+        [ProtoMember(12)]
         public float InitialHeight { get; set; }
 
-        [ProtoMember(14)]
+        [ProtoMember(13)]
         public Tuple<float, float, float> Location { get; set; }
 
-        [ProtoMember(15)]
+        [ProtoMember(14)]
         public bool IsPixelPerfect { get; set; }
 
-        [ProtoMember(16)]
+        [ProtoMember(15)]
         public float ScaleX { get; set; }
 
-        [ProtoMember(17)]
+        [ProtoMember(16)]
         public float ScaleY { get; set; }
 
-        [ProtoMember(18)]
+        [ProtoMember(17)]
         public float Angle { get; set; }
 
-        [ProtoMember(19)]
+        [ProtoMember(18)]
         public uint Tint { get; set; }
 
-        [ProtoMember(20)]
+        [ProtoMember(19)]
         public Tuple<float, float> Pivot { get; set; }
 
-        [ProtoMember(21)]
+        [ProtoMember(20)]
         public Contract<IImage> Image { get; set; }
 
         //todo: support custom renderer deserialization
-        [ProtoMember(22)]
+        [ProtoMember(21)]
         public string CustomRenderer { get; set; }
 
         //todo: save object's previous room
@@ -117,10 +114,6 @@ namespace AGS.Engine
             obj.PixelPerfect(IsPixelPerfect);
             AnimationComponent.ToItem(context, obj);
             obj.RenderLayer = RenderLayer.ToItem(context);
-			if (WalkPoint != null)
-			{
-				obj.WalkPoint = new PointF (WalkPoint.Item1, WalkPoint.Item2);
-			}
             obj.Properties.CopyFrom(Properties.ToItem(context));
 			obj.Enabled = Enabled;
 			obj.DisplayName = DisplayName;
@@ -145,10 +138,6 @@ namespace AGS.Engine
 			AnimationComponent = new ContractAnimationComponent ();
 			AnimationComponent.FromItem(context, item);
 
-			if (item.WalkPoint != null)
-			{
-				WalkPoint = new Tuple<float, float> (item.WalkPoint.Value.X, item.WalkPoint.Value.Y);
-			}
 			Enabled = item.UnderlyingEnabled;
 			Visible = item.UnderlyingVisible;
             DisplayName = item.DisplayName;

--- a/Source/Engine/AGS.Engine/UI/DialogBoxes/AGSSelectFileDialog.cs
+++ b/Source/Engine/AGS.Engine/UI/DialogBoxes/AGSSelectFileDialog.cs
@@ -317,7 +317,7 @@ namespace AGS.Engine
             newObj.Pivot = obj.Pivot;
             newObj.Location = obj.Location;
             newObj.Tint = obj.Tint;
-            newObj.Hotspot = obj.Hotspot;
+            newObj.DisplayName = obj.DisplayName;
             newObj.RenderLayer = obj.RenderLayer;
             newObj.IgnoreViewport = obj.IgnoreViewport;
             newObj.IgnoreScalingArea = obj.IgnoreScalingArea;

--- a/Source/Engine/AGS.Engine/UI/HotspotLabels/HotspotLabel.cs
+++ b/Source/Engine/AGS.Engine/UI/HotspotLabels/HotspotLabel.cs
@@ -39,12 +39,14 @@ namespace AGS.Engine
 		{
             if (_label == null) return;
             IObject obj = _game.HitTest.ObjectAtMousePosition;
-            if (obj == null || (obj.Hotspot == null && !DebugMode)) 
+            IHotspotComponent hotspot = obj?.GetComponent<IHotspotComponent>();
+            string hotspotName = hotspot != null ? obj.DisplayName : null;
+            if (obj == null || (hotspotName == null && !DebugMode))
 			{
 				_label.Visible = false;
 				return;
 			}
-            _label.Text = obj.Hotspot ?? obj.ID ?? "???";
+            _label.Text = hotspotName ?? obj.ID ?? "???";
 			_label.Visible = true;
 		}
 	}

--- a/Source/Engine/AGS.Engine/UI/HotspotLabels/HotspotLabel.cs
+++ b/Source/Engine/AGS.Engine/UI/HotspotLabels/HotspotLabel.cs
@@ -40,13 +40,13 @@ namespace AGS.Engine
             if (_label == null) return;
             IObject obj = _game.HitTest.ObjectAtMousePosition;
             IHotspotComponent hotspot = obj?.GetComponent<IHotspotComponent>();
-            string hotspotName = hotspot != null ? obj.DisplayName : null;
+            string hotspotName = hotspot != null && hotspot.DisplayHotspot ? obj.GetFriendlyName() : null;
             if (obj == null || (hotspotName == null && !DebugMode))
 			{
 				_label.Visible = false;
 				return;
 			}
-            _label.Text = hotspotName ?? obj.ID ?? "???";
+            _label.Text = hotspotName ?? "???";
 			_label.Visible = true;
 		}
 	}

--- a/Source/Engine/AGS.Engine/UI/HotspotLabels/VerbOnHotspotLabel.cs
+++ b/Source/Engine/AGS.Engine/UI/HotspotLabels/VerbOnHotspotLabel.cs
@@ -54,7 +54,7 @@ namespace AGS.Engine
             if (_label == null || _state.Player == null) return;
             IObject obj = _game.HitTest.ObjectAtMousePosition;
             IHotspotComponent hotspot = obj?.GetComponent<IHotspotComponent>();
-            string hotspotName = hotspot != null ? obj.DisplayName : null;
+            string hotspotName = hotspot != null && hotspot.DisplayHotspot ? obj.DisplayName : null;
             if (obj == null || hotspotName == null) 
 			{
 				_label.Visible = false;

--- a/Source/Engine/AGS.Engine/UI/HotspotLabels/VerbOnHotspotLabel.cs
+++ b/Source/Engine/AGS.Engine/UI/HotspotLabels/VerbOnHotspotLabel.cs
@@ -53,7 +53,9 @@ namespace AGS.Engine
 		{
             if (_label == null || _state.Player == null) return;
             IObject obj = _game.HitTest.ObjectAtMousePosition;
-			if (obj == null || obj.Hotspot == null) 
+            IHotspotComponent hotspot = obj?.GetComponent<IHotspotComponent>();
+            string hotspotName = hotspot != null ? obj.DisplayName : null;
+            if (obj == null || hotspotName == null) 
 			{
 				_label.Visible = false;
 				return;
@@ -61,9 +63,9 @@ namespace AGS.Engine
 			_label.Visible = true;
             IInventoryItem inventoryItem = _state.Player.Inventory.ActiveItem;
             string inventoryText = inventoryItem == null ? "" : 
-                inventoryItem.Graphics.Hotspot ?? inventoryItem.CursorGraphics.Hotspot ?? "Item";
+                inventoryItem.Graphics.DisplayName ?? inventoryItem.CursorGraphics.DisplayName ?? "Item";
             
-			_label.Text = getSentence(obj.Hotspot, inventoryText);
+			_label.Text = getSentence(hotspotName, inventoryText);
 
 		}
 

--- a/Source/Tests/Engine/Objects/ObjectTests.cs
+++ b/Source/Tests/Engine/Objects/ObjectTests.cs
@@ -43,8 +43,8 @@ namespace Tests
 				IRoom room = _mocks.Room(true).Object;
 				rooms.Add(room);
 				await obj.ChangeRoomAsync(room);
-				Assert.AreEqual(room, obj.Room, "Room not changed for " + obj.Hotspot ?? "null");
-				Assert.IsNull(obj.PreviousRoom, "Prev room not null for " + obj.Hotspot ?? "null");
+				Assert.AreEqual(room, obj.Room, "Room not changed for " + obj.DisplayName ?? "null");
+				Assert.IsNull(obj.PreviousRoom, "Prev room not null for " + obj.DisplayName ?? "null");
 			}
 		}
 
@@ -65,8 +65,8 @@ namespace Tests
 				rooms.Add(newRoom);
 				await obj.ChangeRoomAsync(oldRoom);
 				await obj.ChangeRoomAsync(newRoom);
-				Assert.AreEqual(newRoom, obj.Room, "Room not changed for " + obj.Hotspot ?? "null");
-				Assert.AreEqual(oldRoom, obj.PreviousRoom, "Prev room incorrect for " + obj.Hotspot ?? "null");
+				Assert.AreEqual(newRoom, obj.Room, "Room not changed for " + obj.DisplayName ?? "null");
+				Assert.AreEqual(oldRoom, obj.PreviousRoom, "Prev room incorrect for " + obj.DisplayName ?? "null");
 			}
 		}
 
@@ -87,8 +87,8 @@ namespace Tests
 				rooms.Add(newRoom);
 				await obj.ChangeRoomAsync(oldRoom);
 				await obj.ChangeRoomAsync(newRoom);
-				Assert.AreEqual(newRoom, obj.Room, "Room not changed for " + obj.Hotspot ?? "null");
-				Assert.AreEqual(oldRoom, obj.PreviousRoom, "Prev room incorrect for " + obj.Hotspot ?? "null");
+				Assert.AreEqual(newRoom, obj.Room, "Room not changed for " + obj.DisplayName ?? "null");
+				Assert.AreEqual(oldRoom, obj.PreviousRoom, "Prev room incorrect for " + obj.DisplayName ?? "null");
 			}
 		}
 
@@ -108,8 +108,8 @@ namespace Tests
 				rooms.Add(oldRoom);
 				await obj.ChangeRoomAsync(oldRoom);
 				await obj.ChangeRoomAsync(newRoom);
-				Assert.AreEqual(newRoom, obj.Room, "Room not changed for " + obj.Hotspot ?? "null");
-				Assert.AreEqual(oldRoom, obj.PreviousRoom, "Prev room incorrect for " + obj.Hotspot ?? "null");
+				Assert.AreEqual(newRoom, obj.Room, "Room not changed for " + obj.DisplayName ?? "null");
+				Assert.AreEqual(oldRoom, obj.PreviousRoom, "Prev room incorrect for " + obj.DisplayName ?? "null");
 			}
 		}
 
@@ -285,7 +285,7 @@ namespace Tests
 	{
 		public static IObject Hotspot(this IObject obj, string hotspot)
 		{
-			obj.Hotspot = hotspot;
+			obj.DisplayName = hotspot;
 			return obj;
 		}
 	}

--- a/Source/Tests/Engine/Serialization/SaveLoadTests.cs
+++ b/Source/Tests/Engine/Serialization/SaveLoadTests.cs
@@ -112,7 +112,6 @@ namespace Tests
 		private void setupObject(IObject obj)
 		{
 			obj.Pivot = new AGS.API.PointF (0.1f, 0.2f);
-			obj.WalkPoint = new AGS.API.PointF (0.3f, 0.4f);
 			obj.Location = new AGSLocation (0.5f, 0.6f, 0.7f);
 			obj.Angle = 0.8f;
 			obj.Image = new EmptyImage (100f, 50f);
@@ -127,8 +126,6 @@ namespace Tests
 		{
 			Assert.AreEqual(0.1f, actual.Pivot.X);
 			Assert.AreEqual(0.2f, actual.Pivot.Y);
-			Assert.AreEqual(0.3f, actual.WalkPoint.Value.X);
-			Assert.AreEqual(0.4f, actual.WalkPoint.Value.Y);
 			Assert.AreEqual(0.5f, actual.X);
 			Assert.AreEqual(0.6f, actual.Y);
 			Assert.AreEqual(0.7f, actual.Z);


### PR DESCRIPTION
This PR strips "adventure layer" from the default IObject type in the engine. This "layer" is actually represented only by IHotspotComponent that contains interaction setup (reaction to player commands).
The idea is to have IObject as a base class for something that has visuals, but not necessary associates with adventure genre (interaction schemes).
The adventure-specific class could be added later (based on Object and having HotspotComponent, and maybe other things).

Besides removing IHotspotComponent from IObject, I had to do following changes:
* Replace Hotspot string property with DisplayName property, added to IEntity. This makes it possible to assign human-readable name or description to any entity in game.
* In exchange, add DisplayHotspot boolean property to IHotspotComponent, which lets to enable or disable showing hotspot's name under mouse cursor.