### PR TITLE
Inspector- Color editor

### DIFF
--- a/Source/AGS.API/Game/Factories/IUIFactory.cs
+++ b/Source/AGS.API/Game/Factories/IUIFactory.cs
@@ -62,9 +62,12 @@ namespace AGS.API
         /// <summary>
         /// Adds horizontal and vertical scrollbars on the edges of the panel that allow to scroll the contents on the panel.
         /// The scrollbars are only shown if the contents is bigger than panel.
+        /// 
+        /// The function expands the given panel by a gutter size which is used to display the scrollbars, and returns 
+        /// a contents panel with the original size, in which to put the scrolled contents.
         /// </summary>
         /// <param name="panel">Panel.</param>
-        void CreateScrollingPanel(IPanel panel);
+        IPanel CreateScrollingPanel(IPanel panel, float gutterSize = 15f);
 
         /// <summary>
         /// Creates a label.

--- a/Source/AGS.API/UI/Controls/Slider/ISliderComponent.cs
+++ b/Source/AGS.API/UI/Controls/Slider/ISliderComponent.cs
@@ -72,6 +72,20 @@
 		float Value { get; set; }
 
         /// <summary>
+        /// Gets or sets an offset for the handle to be placed from the minimum X/Y of the background image.
+        /// This can be useful for properly aligning the handle to the background graphics.
+        /// </summary>
+        /// <value>The minimum handle offset.</value>
+        float MinHandleOffset { get; set; }
+
+        /// <summary>
+        /// Gets or sets an offset for the handle to be placed from the maximum X/Y of the background image.
+        /// This can be useful for properly aligning the handle to the background graphics.
+        /// </summary>
+        /// <value>The minimum handle offset.</value>
+        float MaxHandleOffset { get; set; }
+
+        /// <summary>
         /// Gets or sets a value indicating whether this <see cref="T:AGS.API.ISliderComponent"/> allows keyboard control for moving the slider when it is in focus (i.e after the user clicked on the slider).
         /// Default is true.
         /// </summary>

--- a/Source/Demo/DemoQuest/Characters/Cris.cs
+++ b/Source/Demo/DemoQuest/Characters/Cris.cs
@@ -23,7 +23,8 @@ namespace DemoGame
 
 			_character = game.Factory.Object.GetCharacter("Cris", outfit).Remember(game, c => _character = c);
             _character.SpeechConfig.TextConfig = AGSTextConfig.ChangeColor(_character.SpeechConfig.TextConfig, Colors.OrangeRed, Colors.Black, 1f);
-            _character.AddComponent<IApproachComponent>();
+            var approach = _character.AddComponent<IApproachComponent>();
+            approach.ApproachStyle.ApproachWhenVerb["Talk"] = ApproachHotspots.WalkIfHaveWalkPoint;
 			emitter.Object = _character;
 
 

--- a/Source/Demo/DemoQuest/GUI/FeaturesWindow/FeaturesTweenPanel.cs
+++ b/Source/Demo/DemoQuest/GUI/FeaturesWindow/FeaturesTweenPanel.cs
@@ -15,7 +15,7 @@ namespace DemoGame
         private IButton _addTweenButton, _clearTweensButton;
         private IGame _game;
         private IObject _parent;
-        private IPanel _tweensListPanel, _window;
+        private IPanel _tweensListScrollingPanel, _tweensListContentsPanel, _window;
         private readonly Dictionary<string, List<(string propertyName, Func<Tween> getTween)>> _tweens;
         private readonly Dictionary<string, Func<float, float>> _eases;
         private readonly List<RunningTween> _runningTweens;
@@ -124,15 +124,15 @@ namespace DemoGame
             _addTweenButton.Enabled = false;
             _addTweenButton.Opacity = 100;
             _clearTweensButton = addButton("FeaturesTweenClearAll", "Clear All", _addTweenButton.X, 20f, clearTweens);
-            _tweensListPanel = _game.Factory.UI.GetPanel("FeaturesTweenListPanel", 600f, 250f, 0f, _parent.Height - 200f, parent, false);
-            _tweensListPanel.Tint = Colors.Transparent;
-            _tweensListPanel.Pivot = new PointF(0f, 1f);
-            _tweensListPanel.AddComponent<IBoundingBoxWithChildrenComponent>();
-            _game.Factory.UI.CreateScrollingPanel(_tweensListPanel);
-            var layout = _tweensListPanel.AddComponent<IStackLayoutComponent>();
+            _tweensListScrollingPanel = _game.Factory.UI.GetPanel("FeaturesTweenListPanel", 580f, 250f, 0f, _parent.Height - 200f, parent, false);
+            _tweensListScrollingPanel.Tint = Colors.Transparent;
+            _tweensListContentsPanel = _game.Factory.UI.CreateScrollingPanel(_tweensListScrollingPanel);
+            _tweensListContentsPanel.AddComponent<IBoundingBoxWithChildrenComponent>();
+            _tweensListScrollingPanel.Pivot = new PointF(0f, 1f);
+            var layout = _tweensListContentsPanel.AddComponent<IStackLayoutComponent>();
             layout.Direction = LayoutDirection.Vertical;
             layout.AbsoluteSpacing = -10f;
-            layout.StartLocation = _tweensListPanel.Height - 20f;
+            layout.StartLocation = _tweensListContentsPanel.Height - 20f;
             layout.StartLayout();
         }
 
@@ -145,7 +145,8 @@ namespace DemoGame
             removeComboboxFromUI(_repeatCombobox);
             _game.State.UI.Remove(_addTweenButton);
             _game.State.UI.Remove(_clearTweensButton);
-            _game.State.UI.Remove(_tweensListPanel);
+            _game.State.UI.Remove(_tweensListScrollingPanel);
+            _game.State.UI.Remove(_tweensListContentsPanel);
             _game.State.Viewport.Camera.Enabled = true;
             _game.State.Player.Tint = Colors.White;
             TopBar.InventoryButton.Tint = Colors.White;
@@ -161,7 +162,8 @@ namespace DemoGame
             addComboboxToUI(_repeatCombobox);
             _game.State.UI.Add(_addTweenButton);
             _game.State.UI.Add(_clearTweensButton);
-            _game.State.UI.Add(_tweensListPanel);
+            _game.State.UI.Add(_tweensListScrollingPanel);
+            _game.State.UI.Add(_tweensListContentsPanel);
             _game.State.Viewport.Camera.Enabled = false;
             await AGSMessageBox.DisplayAsync("Don't freak out! We're going to change some of the colors now to make the colored tween effects more visible.");
             _game.State.Player.Tint = Color.FromHsla(0, 0.8f, 0.5f, 255);
@@ -183,7 +185,7 @@ namespace DemoGame
             }
             tween = tween.RepeatForever(looping, 3f);
             _runningTweens.Add(new RunningTween($"{targetText}.{tweenText}", 
-                                                tween, _game, _tweensListPanel));
+                                                tween, _game, _tweensListContentsPanel));
         }
 
         private void clearTweens()

--- a/Source/Engine/AGS.Engine.Desktop/AGSInput.cs
+++ b/Source/Engine/AGS.Engine.Desktop/AGSInput.cs
@@ -1,4 +1,7 @@
 ﻿using System;
+using System.Collections.Concurrent;
+using System.Threading;
+using System.Threading.Tasks;
 using AGS.API;
 using OpenTK;
 using OpenTK.Input;
@@ -17,10 +20,13 @@ namespace AGS.Engine.Desktop
 
         private IObject _mouseCursor;
         private MouseCursor _originalOSCursor;
+        private ConcurrentQueue<Func<Task>> _actions;
+        private int _inUpdate; //For preventing re-entrancy
 
         public AGSInput(GameWindow game, API.Size virtualResolution, IGameState state, IGameEvents events,
                         IShouldBlockInput shouldBlockInput, IGameWindowSize windowSize)
         {
+            _actions = new ConcurrentQueue<Func<Task>>();
             _windowSize = windowSize;
             this._shouldBlockInput = shouldBlockInput;
             API.MousePosition.VirtualResolution = virtualResolution;
@@ -40,38 +46,38 @@ namespace AGS.Engine.Desktop
             KeyDown = new AGSEvent<KeyboardEventArgs>();
             KeyUp = new AGSEvent<KeyboardEventArgs>();
 
-            game.MouseDown += async (sender, e) =>
+            game.MouseDown += (sender, e) =>
             {
                 if (isInputBlocked()) return;
                 var button = convert(e.Button);
-                await MouseDown.InvokeAsync(new AGS.API.MouseButtonEventArgs(null, button, MousePosition));
+                _actions.Enqueue(() => MouseDown.InvokeAsync(new AGS.API.MouseButtonEventArgs(null, button, MousePosition)));
             };
-            game.MouseUp += async (sender, e) =>
+            game.MouseUp += (sender, e) =>
             {
                 if (isInputBlocked()) return;
                 var button = convert(e.Button);
-                await MouseUp.InvokeAsync(new AGS.API.MouseButtonEventArgs(null, button, MousePosition));
+                _actions.Enqueue(() => MouseUp.InvokeAsync(new AGS.API.MouseButtonEventArgs(null, button, MousePosition)));
             };
-            game.MouseMove += async (sender, e) =>
+            game.MouseMove += (sender, e) =>
             {
                 if (isInputBlocked()) return;
                 _mouseX = e.Mouse.X;
                 _mouseY = e.Mouse.Y;
-                await MouseMove.InvokeAsync(new MousePositionEventArgs(MousePosition));
+                _actions.Enqueue(() => MouseMove.InvokeAsync(new MousePositionEventArgs(MousePosition)));
             };
-            game.KeyDown += async (sender, e) =>
+            game.KeyDown += (sender, e) =>
             {
                 API.Key key = convert(e.Key);
                 _keysDown.Add(key);
                 if (isInputBlocked()) return;
-                await KeyDown.InvokeAsync(new KeyboardEventArgs(key));
+                _actions.Enqueue(() => KeyDown.InvokeAsync(new KeyboardEventArgs(key)));
             };
-            game.KeyUp += async (sender, e) =>
+            game.KeyUp += (sender, e) =>
             {
                 API.Key key = convert(e.Key);
                 _keysDown.Remove(key);
                 if (isInputBlocked()) return;
-                await KeyUp.InvokeAsync(new KeyboardEventArgs(key));
+                _actions.Enqueue(() => KeyUp.InvokeAsync(new KeyboardEventArgs(key)));
             };
 
             events.OnRepeatedlyExecute.Subscribe(onRepeatedlyExecute);
@@ -125,11 +131,24 @@ namespace AGS.Engine.Desktop
 			}
 		}
 
-        private void onRepeatedlyExecute()
+        private async void onRepeatedlyExecute()
         {
             var cursorState = Mouse.GetCursorState();
             LeftMouseButtonDown = cursorState.LeftButton == ButtonState.Pressed;
             RightMouseButtonDown = cursorState.RightButton == ButtonState.Pressed;
+
+            if (Interlocked.CompareExchange(ref _inUpdate, 1, 0) != 0) return;
+            try
+            {
+                while (_actions.TryDequeue(out var action))
+                {
+                    await action();
+                }
+            }
+            finally
+            {
+                _inUpdate = 0;   
+            }
         }
 
         private AGS.API.Key convert(OpenTK.Input.Key key) => (AGS.API.Key)(int)key;

--- a/Source/Engine/AGS.Engine.Desktop/AGSInput.cs
+++ b/Source/Engine/AGS.Engine.Desktop/AGSInput.cs
@@ -131,7 +131,7 @@ namespace AGS.Engine.Desktop
 			}
 		}
 
-        private async void onRepeatedlyExecute()
+        private void onRepeatedlyExecute()
         {
             var cursorState = Mouse.GetCursorState();
             LeftMouseButtonDown = cursorState.LeftButton == ButtonState.Pressed;
@@ -142,7 +142,7 @@ namespace AGS.Engine.Desktop
             {
                 while (_actions.TryDequeue(out var action))
                 {
-                    await action();
+                    action();
                 }
             }
             finally

--- a/Source/Engine/AGS.Engine/AGS.Engine.csproj
+++ b/Source/Engine/AGS.Engine/AGS.Engine.csproj
@@ -448,6 +448,7 @@
     <Compile Include="UI\Layouts\TreeTable\TreeTableLayout.cs" />
     <Compile Include="UI\Layouts\TreeTable\AGSTreeTableRowLayoutComponent.cs" />
     <Compile Include="UI\DebugControls\DebugView\GameViewColors.cs" />
+    <Compile Include="UI\DebugControls\DebugView\Inspector\Editors\ColorPropertyEditor.cs" />
   </ItemGroup>
   <Import Project="$(MSBuildExtensionsPath32)\Microsoft\Portable\$(TargetFrameworkVersion)\Microsoft.Portable.CSharp.targets" />
   <ItemGroup>

--- a/Source/Engine/AGS.Engine/ComponentsFramework/AGSComponent.cs
+++ b/Source/Engine/AGS.Engine/ComponentsFramework/AGSComponent.cs
@@ -10,6 +10,8 @@ namespace AGS.Engine
 
         public event PropertyChangedEventHandler PropertyChanged;
 
+        public int GetPropertyChangedSubscriberCount() => PropertyChanged?.GetInvocationList().Length ?? 0;
+
         public AGSComponent()
 		{
 			_type = GetType();

--- a/Source/Engine/AGS.Engine/ComponentsFramework/Templates/AGSSlider.generated.cs
+++ b/Source/Engine/AGS.Engine/ComponentsFramework/Templates/AGSSlider.generated.cs
@@ -135,6 +135,18 @@ namespace AGS.Engine
             set { _sliderComponent.Value = value; } 
         }
 
+        public Single MinHandleOffset
+        {
+            get { return _sliderComponent.MinHandleOffset; }
+            set { _sliderComponent.MinHandleOffset = value; }
+        }
+
+        public Single MaxHandleOffset
+        {
+            get { return _sliderComponent.MaxHandleOffset; }
+            set { _sliderComponent.MaxHandleOffset = value; }
+        }
+
         public Boolean AllowKeyboardControl 
         {  
             get { return _sliderComponent.AllowKeyboardControl; }  

--- a/Source/Engine/AGS.Engine/Game/Factories/AGSUIFactory.cs
+++ b/Source/Engine/AGS.Engine/Game/Factories/AGSUIFactory.cs
@@ -392,14 +392,27 @@ namespace AGS.Engine
 				};
             }
 
-            var dropDownPanel = GetPanel(id + "_DropDownPanel", new EmptyImage(1f, 1f), 0f, 0f, comboBox);
+            var dropDownPanel = GetPanel(id + "_DropDownPanel", new EmptyImage(1f, 1f), 0f, 0f, null, false);
+            dropDownPanel.Visible = false;
+            _gameState.UI.Add(dropDownPanel);
             dropDownPanel.Border = AGSBorders.SolidColor(Colors.White, 3f);
             dropDownPanel.Tint = Colors.Black;
             dropDownPanel.RenderLayer = dropDownPanelLayer;
+            _gameState.FocusedUI.CannotLoseFocus.Add(dropDownPanel.ID);
             var contentsPanel = CreateScrollingPanel(dropDownPanel);
             var listBox = contentsPanel.AddComponent<IListboxComponent>();
             listBox.ItemButtonFactory = itemButtonFactory;
             listBox.MaxHeight = 300f;
+
+            Action placePanel = () =>
+            {
+                var box = textBox.GetBoundingBoxes(_gameState.Viewport)?.RenderBox;
+                if (box == null) return;
+                dropDownPanel.Location = new AGSLocation(box.Value.BottomLeft.X, box.Value.BottomLeft.Y);
+            };
+
+            textBox.OnBoundingBoxesChanged.Subscribe(placePanel);
+            placePanel();
 
             contentsPanel.AddComponent<IBoundingBoxWithChildrenComponent>();
             contentsPanel.AddComponent<IStackLayoutComponent>();

--- a/Source/Engine/AGS.Engine/Game/Factories/AGSUIFactory.cs
+++ b/Source/Engine/AGS.Engine/Game/Factories/AGSUIFactory.cs
@@ -55,58 +55,79 @@ namespace AGS.Engine
             return GetPanel(id, image, x, y, parent, addToUi);
         }
 
-        public void CreateScrollingPanel(IPanel panel)
+        public IPanel CreateScrollingPanel(IPanel panel, float gutterSize = 15f)
         {
-			panel.AddComponent<ICropChildrenComponent>();
-			var box = panel.AddComponent<IBoundingBoxWithChildrenComponent>();
-			IScrollingComponent scroll = panel.AddComponent<IScrollingComponent>();
+            var contentsPanel = GetPanel($"{panel.ID}_Contents", panel.Width, panel.Height, 0f, 0f, panel);
+            contentsPanel.Opacity = 0;
+
+            contentsPanel.RenderLayer = panel.RenderLayer;
+
+            contentsPanel.AddComponent<ICropChildrenComponent>();
+            var box = contentsPanel.AddComponent<IBoundingBoxWithChildrenComponent>();
+            IScrollingComponent scroll = contentsPanel.AddComponent<IScrollingComponent>();
 
             var horizSlider = GetSlider($"{panel.ID}_HorizontalSlider", null, null, 0f, 0f, 0f, panel);
-			horizSlider.HandleGraphics.Pivot = new PointF(0f, 0.5f);
+			horizSlider.HandleGraphics.Pivot = new PointF(0f, 0f);
             horizSlider.Direction = SliderDirection.LeftToRight;
-			horizSlider.Graphics.Pivot = new PointF(0f, 0.5f);
+			horizSlider.Graphics.Pivot = new PointF(0f, 0f);
 			horizSlider.Graphics.Border = AGSBorders.SolidColor(Colors.DarkGray, 0.5f, true);
 			horizSlider.HandleGraphics.Border = AGSBorders.SolidColor(Colors.White, 0.5f, true);
             HoverEffect.Add(horizSlider.Graphics, Colors.Gray, Colors.LightGray);
 			HoverEffect.Add(horizSlider.HandleGraphics, Colors.DarkGray, Colors.WhiteSmoke);
 
             var verSlider = GetSlider($"{panel.ID}_VerticalSlider", null, null, 0f, 0f, 0f, panel);
-			verSlider.HandleGraphics.Pivot = new PointF(0.5f, 0f);
+			verSlider.HandleGraphics.Pivot = new PointF(0f, 0f);
             verSlider.Direction = SliderDirection.TopToBottom;
-			verSlider.Graphics.Pivot = new PointF(0.5f, 0f);
+			verSlider.Graphics.Pivot = new PointF(0f, 0f);
 			verSlider.Graphics.Border = AGSBorders.SolidColor(Colors.DarkGray, 0.5f, true);
 			verSlider.HandleGraphics.Border = AGSBorders.SolidColor(Colors.White, 0.5f, true);
+            verSlider.MaxHandleOffset = gutterSize;
 			HoverEffect.Add(verSlider.Graphics, Colors.Gray, Colors.LightGray);
             HoverEffect.Add(verSlider.HandleGraphics, Colors.DarkGray, Colors.WhiteSmoke);
 
-            box.EntitiesToSkip.AddRange(new List<string>{ horizSlider.ID, horizSlider.HandleGraphics.ID, horizSlider.Graphics.ID,
-                verSlider.ID, verSlider.HandleGraphics.ID, verSlider.Graphics.ID});
+            (var idle, var hovered, var pushed) = getArrowButtonAnimations(ArrowDirection.Up, 1f);
+            var upButton = GetButton($"{panel.ID}_ScrollUpButton", idle, hovered, pushed, 0f, panel.Height - gutterSize * 2f, verSlider, width: gutterSize, height: gutterSize);
+            upButton.Pivot = new PointF(0f, 1f);
+            upButton.MouseClicked.Subscribe(args => verSlider.Value--);
+
+            (idle, hovered, pushed) = getArrowButtonAnimations(ArrowDirection.Down, 1f);
+            var downButton = GetButton($"{panel.ID}_ScrollDownButton", idle, hovered, pushed, 0f, 0f, verSlider, width: gutterSize, height: gutterSize);
+            downButton.Pivot = new PointF(0f, 1f);
+            downButton.MouseClicked.Subscribe(args => verSlider.Value++);
+
+            (idle, hovered, pushed) = getArrowButtonAnimations(ArrowDirection.Left, 1f);
+            var leftButton = GetButton($"{panel.ID}_ScrollUpLeft", idle, hovered, pushed, 0f, 0f, horizSlider, width: gutterSize, height: gutterSize);
+            leftButton.Pivot = new PointF(1f, 0f);
+            leftButton.MouseClicked.Subscribe(args => horizSlider.Value--);
+
+            (idle, hovered, pushed) = getArrowButtonAnimations(ArrowDirection.Right, 1f);
+            var rightButton = GetButton($"{panel.ID}_ScrollDownRight", idle, hovered, pushed, panel.Width - gutterSize * 2f, 0f, horizSlider, width: gutterSize, height: gutterSize);
+            rightButton.Pivot = new PointF(0f, 0f);
+            rightButton.MouseClicked.Subscribe(args => horizSlider.Value++);
 
             PropertyChangedEventHandler resize = (_, args) =>
             {
                 if (args.PropertyName != nameof(IScaleComponent.Width) && args.PropertyName != nameof(IScaleComponent.Height)) return;
-                const float widthFactor = 25f;
-                const float heightFactor = 25f;
-                float widthUnit = panel.Width / widthFactor;
-                float heightUnit = panel.Height / heightFactor;
-                horizSlider.Graphics.Image = new EmptyImage(panel.Width - widthUnit * 2f, heightUnit / 2f);
-                horizSlider.HandleGraphics.Image = new EmptyImage(widthUnit, heightUnit);
-                verSlider.Graphics.Image = new EmptyImage(widthUnit / 2f, panel.Height - heightUnit * 4f);
-                verSlider.HandleGraphics.Image = new EmptyImage(widthUnit, heightUnit);
-                horizSlider.X = -panel.Width * panel.Pivot.X + widthUnit;
-                horizSlider.Y = heightUnit;
-                verSlider.X = panel.Width - widthUnit;
-                verSlider.Y = heightUnit * 2f;
+                panel.BaseSize = new SizeF(contentsPanel.Width + gutterSize, contentsPanel.Height + gutterSize);
+                horizSlider.Graphics.Image = new EmptyImage(panel.Width - gutterSize * 2f, gutterSize);
+                horizSlider.HandleGraphics.Image = new EmptyImage(gutterSize, gutterSize);
+                verSlider.Graphics.Image = new EmptyImage(gutterSize, panel.Height - gutterSize * 3f);
+                verSlider.HandleGraphics.Image = new EmptyImage(gutterSize, gutterSize);
+                horizSlider.X = -panel.Width * panel.Pivot.X + gutterSize;
+                verSlider.X = panel.Width - gutterSize;
+                verSlider.Y = gutterSize * 2f;
+                upButton.Y = panel.Height - gutterSize * 2f;
+                rightButton.X = panel.Width - gutterSize * 2f;
+                contentsPanel.Y = gutterSize;
             };
-
-            panel.Bind<IStackLayoutComponent>(
-                c => c.EntitiesToIgnore.AddRange(new List<string> { verSlider.ID, horizSlider.ID }), _ =>{});
 
             resize(this, new PropertyChangedEventArgs(nameof(IScaleComponent.Width)));
             scroll.HorizontalScrollBar = horizSlider;
 			scroll.VerticalScrollBar = verSlider;
 
-            panel.Bind<IScaleComponent>(c => c.PropertyChanged += resize, c => c.PropertyChanged -= resize);
+            contentsPanel.Bind<IScaleComponent>(c => c.PropertyChanged += resize, c => c.PropertyChanged -= resize);
+
+            return contentsPanel;
         }
 
         public ILabel GetLabel(string id, string text, float width, float height, float x, float y, IObject parent = null, ITextConfig config = null, bool addToUi = true)
@@ -343,18 +364,9 @@ namespace AGS.Engine
 
             if (dropDownButton == null)
             {
-				var whiteArrow = AGSBorders.Multiple(AGSBorders.SolidColor(Colors.WhiteSmoke, 3f),
-												 _graphics.Icons.GetArrowIcon(ArrowDirection.Down, Colors.WhiteSmoke));
-				var yellowArrow = AGSBorders.Multiple(AGSBorders.SolidColor(Colors.Yellow, 3f),
-													  _graphics.Icons.GetArrowIcon(ArrowDirection.Down, Colors.Yellow));
-				dropDownButton = GetButton(id + "_DropDownButton",
-                                                                  new ButtonAnimation(whiteArrow, null, Colors.Transparent),
-                                                                  new ButtonAnimation(yellowArrow, null, Colors.Transparent),
-                                                                  new ButtonAnimation(yellowArrow, null, Colors.White.WithAlpha(100)),
-                                                                  0f, 0f, comboBox, "", null,
-                                                                  false, 30f, defaultHeight);
-
-				dropDownButton.Border = whiteArrow;
+                (var idle, var hovered, var pushed) = getArrowButtonAnimations(ArrowDirection.Down, 3f);
+				dropDownButton = GetButton(id + "_DropDownButton", idle, hovered, pushed, 0f, 0f, comboBox, "", null, false, 30f, defaultHeight);
+                dropDownButton.Border = idle.Border;
 			}
 			else setParent(dropDownButton, comboBox);
             dropDownButton.RenderLayer = comboBox.RenderLayer;
@@ -381,19 +393,20 @@ namespace AGS.Engine
             }
 
             var dropDownPanel = GetPanel(id + "_DropDownPanel", new EmptyImage(1f, 1f), 0f, 0f, comboBox);
-            dropDownPanel.AddComponent<IBoundingBoxWithChildrenComponent>();
-            dropDownPanel.AddComponent<IStackLayoutComponent>();
             dropDownPanel.Border = AGSBorders.SolidColor(Colors.White, 3f);
             dropDownPanel.Tint = Colors.Black;
             dropDownPanel.RenderLayer = dropDownPanelLayer;
-            var listBox = dropDownPanel.AddComponent<IListboxComponent>();
+            var contentsPanel = CreateScrollingPanel(dropDownPanel);
+            var listBox = contentsPanel.AddComponent<IListboxComponent>();
             listBox.ItemButtonFactory = itemButtonFactory;
             listBox.MaxHeight = 300f;
-            CreateScrollingPanel(dropDownPanel);
+
+            contentsPanel.AddComponent<IBoundingBoxWithChildrenComponent>();
+            contentsPanel.AddComponent<IStackLayoutComponent>();
 
             comboBox.DropDownButton = dropDownButton;
             comboBox.TextBox = textBox;
-            comboBox.DropDownPanel = dropDownPanel;
+            comboBox.DropDownPanel = contentsPanel;
 
             setParent(comboBox, parent);
 
@@ -463,6 +476,18 @@ namespace AGS.Engine
             if (addToUi)
                 _gameState.UI.Add(slider);
             return slider;
+        }
+
+        private (ButtonAnimation idle, ButtonAnimation hovered, ButtonAnimation pushed) getArrowButtonAnimations(ArrowDirection direction, float lineWidth)
+        {
+            var whiteArrow = AGSBorders.Multiple(AGSBorders.SolidColor(Colors.WhiteSmoke, lineWidth),
+                                                 _graphics.Icons.GetArrowIcon(direction, Colors.WhiteSmoke));
+            var yellowArrow = AGSBorders.Multiple(AGSBorders.SolidColor(Colors.Yellow, lineWidth),
+                                                  _graphics.Icons.GetArrowIcon(direction, Colors.Yellow));
+
+            return (new ButtonAnimation(whiteArrow, null, Colors.Transparent),
+                    new ButtonAnimation(yellowArrow, null, Colors.Transparent),
+                    new ButtonAnimation(yellowArrow, null, Colors.White.WithAlpha(100)));
         }
 
         private ButtonAnimation validateAnimation(string id, ButtonAnimation button, Func<ButtonAnimation> defaultAnimation, float width, float height)

--- a/Source/Engine/AGS.Engine/Graphics/Logic/DisplayList/AGSDisplayList.cs
+++ b/Source/Engine/AGS.Engine/Graphics/Logic/DisplayList/AGSDisplayList.cs
@@ -55,7 +55,7 @@ namespace AGS.Engine
             }
         }
 
-        private struct AnimationSubscriber
+        private class AnimationSubscriber
         {
             private IAnimation _lastAnimation;
             private ISprite _lastSprite;

--- a/Source/Engine/AGS.Engine/Objects/AGSBoundingBoxWithChildrenComponent.cs
+++ b/Source/Engine/AGS.Engine/Objects/AGSBoundingBoxWithChildrenComponent.cs
@@ -148,7 +148,7 @@ namespace AGS.Engine
             _preCropBoundingBoxWithChildren = getBoundingBox(_tree, _boundingBox, boxes => boxes.PreCropRenderBox, DebugPrintouts ? $"Box Pre Crop ({_entity.ID})" : null);
             if (DebugPrintouts)
             {
-                Debug.WriteLine($"Pre crop for {_entity.ID}: {_preUnlockBoundingBox.ToString()}");
+                Debug.WriteLine($"Pre crop for {_entity.ID}: {_preCropBoundingBoxWithChildren.ToString()}");
             }
             return (!lastBox.Equals(BoundingBoxWithChildren) || !lastPreBox.Equals(PreCropBoundingBoxWithChildren));
         }

--- a/Source/Engine/AGS.Engine/Objects/AGSBoundingBoxWithChildrenComponent.cs
+++ b/Source/Engine/AGS.Engine/Objects/AGSBoundingBoxWithChildrenComponent.cs
@@ -148,7 +148,7 @@ namespace AGS.Engine
             _preCropBoundingBoxWithChildren = getBoundingBox(_tree, _boundingBox, boxes => boxes.PreCropRenderBox, DebugPrintouts ? $"Box Pre Crop ({_entity.ID})" : null);
             if (DebugPrintouts)
             {
-                Debug.WriteLine($"Pre crop for ${_entity.ID}: {_preUnlockBoundingBox.ToString()}");
+                Debug.WriteLine($"Pre crop for {_entity.ID}: {_preUnlockBoundingBox.ToString()}");
             }
             return (!lastBox.Equals(BoundingBoxWithChildren) || !lastPreBox.Equals(PreCropBoundingBoxWithChildren));
         }
@@ -180,10 +180,13 @@ namespace AGS.Engine
             {
                 var boundingBox = getBox(boxes);
 
-                minX = boundingBox.MinX;
-                maxX = boundingBox.MaxX;
-                minY = boundingBox.MinY;
-                maxY = boundingBox.MaxY;
+                if (boundingBox.IsValid)
+                {
+                    minX = boundingBox.MinX;
+                    maxX = boundingBox.MaxX;
+                    minY = boundingBox.MinY;
+                    maxY = boundingBox.MaxY;
+                }
 
                 if (printoutId != null)
                 {

--- a/Source/Engine/AGS.Engine/Objects/AGSModelMatrixComponent.cs
+++ b/Source/Engine/AGS.Engine/Objects/AGSModelMatrixComponent.cs
@@ -329,10 +329,8 @@ namespace AGS.Engine
 
         private Matrix4 getMatrix(PointF resolutionFactor) 
         {
-            if (_spriteRender == null || _spriteRender.CurrentSprite == null)
-                return Matrix4.Identity;
-            var sprite = _spriteRender.CurrentSprite;
-            Matrix4 spriteMatrix = getModelMatrix(sprite, sprite, sprite, sprite, null,
+            var sprite = _spriteRender?.CurrentSprite;
+            Matrix4 spriteMatrix = sprite == null ? Matrix4.Identity : getModelMatrix(sprite, sprite, sprite, sprite, null,
                                                   NoScaling, resolutionFactor, true);
             Matrix4 objMatrix = getModelMatrix(_scale, _rotate, _translate, _image,
                                                _jump, _areaScaling, resolutionFactor, true);

--- a/Source/Engine/AGS.Engine/Objects/Collisions/AGSBoundingBoxComponent.cs
+++ b/Source/Engine/AGS.Engine/Objects/Collisions/AGSBoundingBoxComponent.cs
@@ -19,6 +19,7 @@ namespace AGS.Engine
         private IModelMatrixComponent _matrix;
         private ICropSelfComponent _crop;
         private ISpriteRenderComponent _spriteRender;
+        private IScaleComponent _scale;
         private IDrawableInfoComponent _drawable;
         private ITextureOffsetComponent _textureOffset;
         private IGameSettings _settings;
@@ -60,6 +61,7 @@ namespace AGS.Engine
             entity.Bind<IImageComponent>(c => c.PropertyChanged += onImageChanged,
                                          c => c.PropertyChanged -= onImageChanged);
             entity.Bind<ISpriteRenderComponent>(c => _spriteRender = c, _ => _spriteRender = null);
+            entity.Bind<IScaleComponent>(c => _scale = c, _ => _scale = null);
             entity.Bind<IDrawableInfoComponent>(c => { c.PropertyChanged += onDrawableChanged; _drawable = c; },
                                        c => { c.PropertyChanged -= onDrawableChanged; _drawable = null; });
             entity.Bind<ITextureOffsetComponent>(c => { c.PropertyChanged += onTextureOffsetChanged; _textureOffset = c; onAllViewportsShouldChange(); }, 
@@ -123,10 +125,9 @@ namespace AGS.Engine
                 if (!viewportBoxes.IsDirty) return boundingBoxes;
                 if (_drawable?.IgnoreViewport ?? false) return boundingBoxes;
             }
-            var image = _spriteRender?.CurrentSprite?.Image;
             var drawable = _drawable;
             var matrix = _matrix;
-            if (image == null || drawable == null || matrix == null) 
+            if (drawable == null || matrix == null) 
                 return boundingBoxes;
             var boxes = recalculate(viewport, viewportBoxes);
             OnBoundingBoxesChanged.Invoke();
@@ -136,21 +137,23 @@ namespace AGS.Engine
         private AGSBoundingBoxes recalculate(IViewport viewport, ViewportBoundingBoxes viewportBoxes)
         {
             var boundingBoxes = viewportBoxes.BoundingBoxes;
-            var sprite = _spriteRender?.CurrentSprite;
             var drawable = _drawable;
 			var matrix = _matrix;
+            var scale = _scale;
+            var sprite = _spriteRender?.CurrentSprite;
             bool isHitTestBoxDirty = _isHitTestBoxDirty;
 
-            if (sprite?.Image == null || drawable == null || matrix == null)
+            if (scale == null || drawable == null || matrix == null)
             {
                 return boundingBoxes;
             }
 
+            var baseSize = sprite?.BaseSize ?? scale.BaseSize;
             if (isHitTestBoxDirty)
             {
                 _isCropDirty = true;
                 _isHitTestBoxDirty = false;
-                updateHitTestBox(sprite, drawable, matrix);
+                updateHitTestBox(baseSize, drawable, matrix);
             }
             var crop = _crop;
 
@@ -168,8 +171,8 @@ namespace AGS.Engine
             AGSBoundingBox intermediateBox, hitTestBox;
             hitTestBox = _hitTestBox;
 
-			float width = sprite.BaseSize.Width;
-			float height = sprite.BaseSize.Height;
+            float width = baseSize.Width;
+            float height = baseSize.Height;
 
 			if (resolutionMatches)
             {
@@ -202,11 +205,12 @@ namespace AGS.Engine
             else
             {
                 var textureOffset = _textureOffset;
-                if (width != sprite.Image.Width || height != sprite.Image.Height ||
-                    (!textureOffset?.TextureOffset.Equals(Vector2.Zero) ?? false))
+                var image = sprite?.Image;
+                if (image != null && (width != image.Width || height != image.Height ||
+                                      (!textureOffset?.TextureOffset.Equals(Vector2.Zero) ?? false)))
                 {
                     var offset = textureOffset?.TextureOffset ?? PointF.Empty;
-                    setProportionalTextureSize(boundingBoxes, sprite, width, height, offset);
+                    setProportionalTextureSize(boundingBoxes, image, width, height, offset);
                 }
                 else boundingBoxes.TextureBox = null;
             }
@@ -225,17 +229,17 @@ namespace AGS.Engine
 		}
 
         private static void setProportionalTextureSize(AGSBoundingBoxes boundingBoxes,
-                           ISprite sprite, float width, float height, PointF textureOffset)
+                           IImage image, float width, float height, PointF textureOffset)
         {
             float left = textureOffset.X;
             float top = textureOffset.Y;
-            float right = width / sprite.Image.Width + textureOffset.X;
-            float bottom = height / sprite.Image.Height + textureOffset.Y;
+            float right = width / image.Width + textureOffset.X;
+            float bottom = height / image.Height + textureOffset.Y;
             boundingBoxes.TextureBox = new FourCorners<Vector2>(new Vector2(left, bottom), new Vector2(right, bottom),
                                                                 new Vector2(left, top), new Vector2(right, top));
         }
 
-        private void updateHitTestBox(ISprite sprite, IDrawableInfoComponent drawable, IModelMatrixComponent matrix)
+        private void updateHitTestBox(SizeF size, IDrawableInfoComponent drawable, IModelMatrixComponent matrix)
         {
             var modelMatrices = matrix.GetModelMatrices();
             var modelMatrix = modelMatrices.InVirtualResolutionMatrix;
@@ -245,8 +249,8 @@ namespace AGS.Engine
 			bool resolutionMatches = AGSModelMatrixComponent.GetVirtualResolution(false, _settings.VirtualResolution,
 												 drawable, null, out resolutionFactor, out resolution);
             
-            float width = sprite.BaseSize.Width / resolutionFactor.X;
-			float height = sprite.BaseSize.Height / resolutionFactor.Y;
+            float width = size.Width / resolutionFactor.X;
+            float height = size.Height / resolutionFactor.Y;
             _intermediateBox = _boundingBoxBuilder.BuildIntermediateBox(width, height, ref modelMatrix);
             _hitTestBox = _boundingBoxBuilder.BuildHitTestBox(ref _intermediateBox);
 		}

--- a/Source/Engine/AGS.Engine/Objects/Collisions/AGSBoundingBoxComponent.cs
+++ b/Source/Engine/AGS.Engine/Objects/Collisions/AGSBoundingBoxComponent.cs
@@ -30,13 +30,14 @@ namespace AGS.Engine
         private readonly AGSCropInfo _defaultCropInfo = default;
 
         public AGSBoundingBoxComponent(IRuntimeSettings settings, IGLViewportMatrixFactory layerViewports,
-                                       IBoundingBoxBuilder boundingBoxBuilder, IGameState state, IGameEvents events)
+                                       IBoundingBoxBuilder boundingBoxBuilder, IGameState state, IGameEvents events,
+                                       IBlockingEvent onBoundingBoxChanged)
         {
             _boundingBoxes = new ConcurrentDictionary<IViewport, ViewportBoundingBoxes>(new IdentityEqualityComparer<IViewport>());
             _boundingBoxes.TryAdd(state.Viewport, new ViewportBoundingBoxes(state.Viewport));
             _settings = settings;
             _state = state;
-            OnBoundingBoxesChanged = new AGSEvent();
+            OnBoundingBoxesChanged = onBoundingBoxChanged;
             _layerViewports = layerViewports;
             _boundingBoxBuilder = boundingBoxBuilder;
             boundingBoxBuilder.OnNewBoxBuildRequired.Subscribe(onHitTextBoxShouldChange);

--- a/Source/Engine/AGS.Engine/UI/Controls/ComboBox/AGSComboBoxComponent.cs
+++ b/Source/Engine/AGS.Engine/UI/Controls/ComboBox/AGSComboBoxComponent.cs
@@ -12,7 +12,6 @@ namespace AGS.Engine
         private IButton _dropDownButton;
         private IListboxComponent _dropDownPanelList;
         private IVisibleComponent _dropDownPanelVisible;
-        private IDrawableInfoComponent _dropDownPanelDrawable;
         private IScrollingComponent _scrolling;
         private IEntity _dropDownPanel;
         private ComboSuggest _suggestMode;
@@ -71,19 +70,19 @@ namespace AGS.Engine
             set 
             {
                 _dropDownPanel = value;
-                var visibleComponent = value.GetComponent<IVisibleComponent>();
-                var drawableComponent = value.GetComponent<IDrawableInfoComponent>();
+                var scrollingContainer = value.GetComponent<IInObjectTreeComponent>()?.TreeNode.Parent ?? value;
+                var visibleComponent = scrollingContainer.GetComponent<IVisibleComponent>();
                 var listBoxComponent = value.GetComponent<IListboxComponent>();
+                var scrollingImageComponent = scrollingContainer.GetComponent<IImageComponent>();
                 var imageComponent = value.GetComponent<IImageComponent>();
                 var translateComponent = value.GetComponent<ITranslateComponent>();
                 _scrolling = value.GetComponent<IScrollingComponent>();
                 _dropDownPanelVisible = visibleComponent;
-                _dropDownPanelDrawable = drawableComponent;
 
                 _dropDownPanelList?.OnSelectedItemChanged.Unsubscribe(onSelectedItemChanged);
                 _dropDownPanelList = listBoxComponent;
                 listBoxComponent?.OnSelectedItemChanged.Subscribe(onSelectedItemChanged);
-                if (imageComponent != null) imageComponent.Pivot = new PointF(0f, 1f);
+                if (scrollingImageComponent != null) scrollingImageComponent.Pivot = new PointF(0f, 1f);
                 if (translateComponent != null) translateComponent.Y = -1f;
                 if (visibleComponent != null) visibleComponent.Visible = false;
             }

--- a/Source/Engine/AGS.Engine/UI/Controls/ComboBox/AGSComboBoxComponent.cs
+++ b/Source/Engine/AGS.Engine/UI/Controls/ComboBox/AGSComboBoxComponent.cs
@@ -114,7 +114,7 @@ namespace AGS.Engine
             switch (args.PressedKey)
             {
                 case Key.Enter:
-                    if (_suggestMode == ComboSuggest.Enforce)
+                    if (_suggestMode == ComboSuggest.Enforce || _currentlyNavigatingSuggestions)
                     {
                         var matchingItem = dropDownPanel.Items.FirstOrDefault(c => c.Text.ToLowerInvariant() != args.IntendedState.Text.ToLowerInvariant());
                         if (matchingItem == null || _currentlyNavigatingSuggestions)

--- a/Source/Engine/AGS.Engine/UI/Controls/Listbox/AGSListboxComponent.cs
+++ b/Source/Engine/AGS.Engine/UI/Controls/Listbox/AGSListboxComponent.cs
@@ -147,6 +147,7 @@ namespace AGS.Engine
 
         private void onListChanged(AGSListChangedEventArgs<IStringItem> args)
         {
+            _layout?.StopLayout();
             var tree = _tree;
             if (args.ChangeType == ListChangeType.Remove)
             {
@@ -180,6 +181,7 @@ namespace AGS.Engine
                 tree?.TreeNode.AddChildren(newButtons);
             }
             refreshItemsLayout();
+            _layout?.StartLayout();
         }
 
         private void onLayoutChanged()

--- a/Source/Engine/AGS.Engine/UI/Controls/Panel/AGSScrollingComponent.cs
+++ b/Source/Engine/AGS.Engine/UI/Controls/Panel/AGSScrollingComponent.cs
@@ -27,7 +27,6 @@ namespace AGS.Engine
                 _verticalScrollBar?.OnValueChanged.Unsubscribe(onVerticalSliderChanged);
                 if (value != null)
                 {
-                    _crop?.EntitiesToSkipCrop.Add(value.ID);
                     value.OnValueChanged.Subscribe(onVerticalSliderChanged);
                 }
                 _verticalScrollBar = value;
@@ -43,7 +42,6 @@ namespace AGS.Engine
 				_horizontalScrollBar?.OnValueChanged.Unsubscribe(onHorizontalSliderChanged);
                 if (value != null)
                 {
-                    _crop?.EntitiesToSkipCrop.Add(value.ID);
                     value.OnValueChanged.Subscribe(onHorizontalSliderChanged);
                 }
 				_horizontalScrollBar = value;
@@ -55,19 +53,7 @@ namespace AGS.Engine
         {
             base.Init(entity);
             _entity = entity;
-            entity.Bind<ICropChildrenComponent>(c => {
-                _crop = c;
-                var verticalScrollBar = VerticalScrollBar;
-                if (verticalScrollBar != null)
-                {
-                    c.EntitiesToSkipCrop.Add(verticalScrollBar.ID);
-                }
-                var horizontalScrollBar = HorizontalScrollBar;
-                if (horizontalScrollBar != null)
-                {
-                    c.EntitiesToSkipCrop.Add(horizontalScrollBar.ID);
-                }
-            }, _ => _crop = null);
+            entity.Bind<ICropChildrenComponent>(c => _crop = c, _ => _crop = null);
 
             //Note: we're subscribing both to the bounding box changed and bounding box with children events.
             //The bounding box event is for the scrolling container, and the box with children is for the scrolling content.
@@ -93,7 +79,7 @@ namespace AGS.Engine
             if (_inEvent) return;
             var container = _boundingBox?.GetBoundingBoxes(_state.Viewport)?.RenderBox;
             var withChildren = _boundingBoxWithChildren?.PreCropBoundingBoxWithChildren;
-            if (container == null || withChildren == null) return;
+            if (container == null || !container.Value.IsValid || withChildren == null || !withChildren.Value.IsValid) return;
 
 			var verticalScrollBar = _verticalScrollBar;
             if (verticalScrollBar != null)

--- a/Source/Engine/AGS.Engine/UI/Controls/Slider/AGSSliderComponent.cs
+++ b/Source/Engine/AGS.Engine/UI/Controls/Slider/AGSSliderComponent.cs
@@ -1,4 +1,5 @@
 ﻿using System.ComponentModel;
+using System.Diagnostics;
 using AGS.API;
 
 namespace AGS.Engine
@@ -98,7 +99,8 @@ namespace AGS.Engine
             {
                 if (MathUtils.FloatEquals(_minValue, value)) return;
                 _minValue = value;
-                refresh();
+                if (Value < _minValue) Value = _minValue;
+                else refresh();
             }
         }
 
@@ -112,7 +114,8 @@ namespace AGS.Engine
             {
                 if (MathUtils.FloatEquals(_maxValue, value)) return;
                 _maxValue = value;
-                refresh();
+                if (Value > _maxValue) Value = _maxValue;
+                else refresh();
             }
         }
 

--- a/Source/Engine/AGS.Engine/UI/Controls/Slider/AGSSliderComponent.cs
+++ b/Source/Engine/AGS.Engine/UI/Controls/Slider/AGSSliderComponent.cs
@@ -8,7 +8,7 @@ namespace AGS.Engine
         private bool _isSliding;
         private IObject _graphics, _handleGraphics;
         private ILabel _label;
-        private float _minValue, _maxValue, _value;
+        private float _minValue, _maxValue, _value, _minHandleOffset, _maxHandleOffset;
         private SliderDirection _direction;
         private IEntity _entity;
 
@@ -112,6 +112,34 @@ namespace AGS.Engine
             {
                 if (MathUtils.FloatEquals(_maxValue, value)) return;
                 _maxValue = value;
+                refresh();
+            }
+        }
+
+        public float MinHandleOffset
+        {
+            get
+            {
+                return _minHandleOffset;
+            }
+            set
+            {
+                if (MathUtils.FloatEquals(_minHandleOffset, value)) return;
+                _minHandleOffset = value;
+                refresh();
+            }
+        }
+
+        public float MaxHandleOffset
+        {
+            get
+            {
+                return _maxHandleOffset;
+            }
+            set
+            {
+                if (MathUtils.FloatEquals(_maxHandleOffset, value)) return;
+                _maxHandleOffset = value;
                 refresh();
             }
         }
@@ -304,8 +332,8 @@ namespace AGS.Engine
 		{
 			float min = isReverse() ? MaxValue : MinValue;
 			float max = isReverse() ? MinValue : MaxValue;
-            return MathUtils.Lerp(min, 0f, max, isHorizontal() ? 
-                                  scale.Width : scale.Height, 
+            return MathUtils.Lerp(min, _minHandleOffset, max, isHorizontal() ? 
+                                  scale.Width - _maxHandleOffset : scale.Height - _maxHandleOffset, 
                                   value);
 		}
 

--- a/Source/Engine/AGS.Engine/UI/Controls/Tree/AGSTreeNodeViewProvider.cs
+++ b/Source/Engine/AGS.Engine/UI/Controls/Tree/AGSTreeNodeViewProvider.cs
@@ -24,11 +24,6 @@ namespace AGS.Engine
                 label.TextConfig = textConfig;
                 label.Text = item.Text;
                 label.TextBackgroundVisible = isSelected;
-                item.PropertyChanged += (sender, e) => 
-                {
-                    if (e.PropertyName != nameof(ITreeStringNode.Text)) return;
-                    label.Text = item.Text;
-                };
             }
             nodeView.TreeItem.Tint = isSelected ? Colors.DarkSlateBlue : Colors.Transparent;
             var expandButton = nodeView.ExpandButton;
@@ -79,6 +74,12 @@ namespace AGS.Engine
             layout.RelativeSpacing = 1f;
             layout.Direction = LayoutDirection.Horizontal;
             layout.StartLayout();
+
+            item.PropertyChanged += (sender, e) =>
+            {
+                if (e.PropertyName != nameof(ITreeStringNode.Text)) return;
+                label.Text = item.Text;
+            };
 
             var nodeView = new AGSTreeNodeView(label, expandButton, parentPanel, verticalPanel, horizontalPanel);
             return nodeView;

--- a/Source/Engine/AGS.Engine/UI/Controls/Tree/AGSTreeViewComponent.cs
+++ b/Source/Engine/AGS.Engine/UI/Controls/Tree/AGSTreeViewComponent.cs
@@ -575,7 +575,7 @@ namespace AGS.Engine
                 if (view == null) return;
                 if (_tree.SkipRenderingRoot && Parent == null)
                 {
-                    view.ExpandButton.Visible = false;
+                    view.HorizontalPanel.Visible = false;
                     return;
                 }
                 view.ParentPanel.Visible = !(Parent?.IsCollapsed ?? false) && FilterMode != SearchFilterMode.NotVisible;

--- a/Source/Engine/AGS.Engine/UI/DebugControls/DebugView/GameDebugDisplayList.cs
+++ b/Source/Engine/AGS.Engine/UI/DebugControls/DebugView/GameDebugDisplayList.cs
@@ -9,11 +9,14 @@ namespace AGS.Engine
     {
         private List<IObject> _lastDisplayList;
         private IListboxComponent _listBox;
-        private IPanel _listPanel, _scrollingPanel, _parent;
+        private IPanel _listPanel, _scrollingPanel, _contentsPanel, _parent;
         private ITextBox _searchBox;
         private IStackLayoutComponent _layout;
         private readonly IRenderLayer _layer;
         private readonly IGame _game;
+
+        const float _gutterSize = 15f;
+        const float _padding = 42f;
 
         public GameDebugDisplayList(IGame game, IRenderLayer layer)
         {
@@ -37,15 +40,15 @@ namespace AGS.Engine
             _searchBox.Visible = false;
             _searchBox.GetComponent<ITextComponent>().PropertyChanged += onSearchPropertyChanged;
 
-            _scrollingPanel = factory.UI.GetPanel("GameDebugDisplayListScrollingPanel", parent.Width, parent.Height - _searchBox.Height, 0f, 0f, parent);
+            _scrollingPanel = factory.UI.GetPanel("GameDebugDisplayListScrollingPanel", parent.Width - _gutterSize, parent.Height - _searchBox.Height - _gutterSize, 0f, 0f, parent);
 			_scrollingPanel.RenderLayer = _layer;
 			_scrollingPanel.Pivot = new PointF(0f, 0f);
 			_scrollingPanel.Tint = Colors.Transparent;
             _scrollingPanel.Border = AGSBorders.SolidColor(GameViewColors.Border, 2f);
             _scrollingPanel.Visible = false;
+            _contentsPanel = factory.UI.CreateScrollingPanel(_scrollingPanel);
 
-            const float lineHeight = 42f;
-            _listPanel = factory.UI.GetPanel("GameDebugDisplayListPanel", 1f, 1f, 0f, _scrollingPanel.Height - lineHeight, _scrollingPanel);
+            _listPanel = factory.UI.GetPanel("GameDebugDisplayListPanel", 1f, 1f, 0f, _contentsPanel.Height - _padding, _contentsPanel);
             _listPanel.Tint = Colors.Transparent;
             _listPanel.RenderLayer = _layer;
             _listPanel.Pivot = new PointF(0f, 1f);
@@ -64,12 +67,11 @@ namespace AGS.Engine
                 button.RenderLayer = parent.RenderLayer;
                 return button;
             };
-            factory.UI.CreateScrollingPanel(_scrollingPanel);
             parent.GetComponent<IScaleComponent>().PropertyChanged += (_, args) =>
 			{
                 if (args.PropertyName != nameof(IScaleComponent.Height)) return;
-                _scrollingPanel.Image = new EmptyImage(_scrollingPanel.Width, parent.Height - _searchBox.Height);
-                _listPanel.Y = _scrollingPanel.Height - 10f;
+                _contentsPanel.BaseSize = new SizeF(_contentsPanel.Width, parent.Height - _searchBox.Height - _gutterSize);
+                _listPanel.Y = _contentsPanel.Height - _padding;
                 _searchBox.Y = _parent.Height;
 			};
         }
@@ -92,7 +94,7 @@ namespace AGS.Engine
 
 		public void Resize()
 		{
-			_scrollingPanel.Image = new EmptyImage(_parent.Width, _scrollingPanel.Image.Height);
+            _contentsPanel.BaseSize = new SizeF(_parent.Width - _gutterSize, _contentsPanel.Height);
             _searchBox.LabelRenderSize = new SizeF(_parent.Width, _searchBox.Height);
             _searchBox.Watermark.LabelRenderSize = new SizeF(_parent.Width, _searchBox.Height);
 		}

--- a/Source/Engine/AGS.Engine/UI/DebugControls/DebugView/Inspector/AGSInspector.cs
+++ b/Source/Engine/AGS.Engine/UI/DebugControls/DebugView/Inspector/AGSInspector.cs
@@ -200,6 +200,8 @@ namespace AGS.Engine
 
             var propType = property.Prop.PropertyType;
             if (propType == typeof(bool)) editor = new BoolPropertyEditor(_factory);
+            else if (propType == typeof(Color)) 
+                editor = new ColorPropertyEditor(_factory);
 
             else if (propType == typeof(int)) editor = new NumberPropertyEditor(_state, _factory, true, false);
             else if (propType == typeof(float)) editor = new NumberPropertyEditor(_state, _factory, false, false);

--- a/Source/Engine/AGS.Engine/UI/DebugControls/DebugView/Inspector/Editors/ColorPropertyEditor.cs
+++ b/Source/Engine/AGS.Engine/UI/DebugControls/DebugView/Inspector/Editors/ColorPropertyEditor.cs
@@ -1,0 +1,186 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.Reflection;
+using AGS.API;
+
+namespace AGS.Engine
+{
+    public class ColorPropertyEditor : IInspectorPropertyEditor
+    {
+        private readonly IGameFactory _factory;
+        private InspectorProperty _property;
+        private ITextBox _text;
+        private ILabel _colorLabel;
+        private IButton _dropDownButton;
+        private Dictionary<string, uint> _namedColors;
+        private Dictionary<uint, string> _namedColorsReversed;
+
+        public ColorPropertyEditor(IGameFactory factory)
+        {
+            _factory = factory;
+            _namedColors = new Dictionary<string, uint>();
+            _namedColorsReversed = new Dictionary<uint, string>();
+        }
+
+        public void AddEditorUI(string id, ITreeNodeView view, InspectorProperty property)
+        {
+            _property = property;
+            var label = view.TreeItem;
+            var combobox = _factory.UI.GetComboBox(id, null, null, null, label.TreeNode.Parent, defaultWidth: 200f, defaultHeight: 25f);
+            _dropDownButton = combobox.DropDownButton;
+            _text = combobox.TextBox;
+            _text.TextBackgroundVisible = false;
+            var list = new List<IStringItem>();
+            foreach (var field in typeof(Colors).GetTypeInfo().DeclaredFields)
+            {
+                list.Add(new AGSStringItem { Text = field.Name });
+                Color color = (Color)field.GetValue(null);
+                _namedColors[field.Name] = color.Value;
+                _namedColorsReversed[color.Value] = field.Name;
+            }
+            combobox.DropDownPanelList.Items.AddRange(list);
+            combobox.Z = label.Z;
+
+            _colorLabel = _factory.UI.GetLabel($"{id}_ColorLabel", "", 50f, 25f, combobox.Width + 10f, 0f, label.TreeNode.Parent);
+            _colorLabel.TextVisible = false;
+
+            RefreshUI();
+            _text.TextConfig.AutoFit = AutoFit.TextShouldFitLabel;
+            _text.TextConfig.Alignment = Alignment.MiddleLeft;
+            _text.TextBackgroundVisible = true;
+            _text.Border = AGSBorders.SolidColor(Colors.White, 2f);
+            var whiteBrush = _text.TextConfig.Brush;
+            var yellowBrush = _factory.Graphics.Brushes.LoadSolidBrush(Colors.Yellow);
+            _text.MouseEnter.Subscribe(_ => { _text.TextConfig.Brush = yellowBrush; });
+            _text.MouseLeave.Subscribe(_ => { _text.TextConfig.Brush = whiteBrush; });
+            _text.OnPressingKey.Subscribe(onTextboxPressingKey);
+            combobox.SuggestMode = ComboSuggest.Suggest;
+            combobox.DropDownPanelList.OnSelectedItemChanged.Subscribe(args =>
+            {
+                property.Prop.SetValue(property.Object, Color.FromHexa(_namedColors[args.Item.Text]));
+            });
+        }
+
+        public void RefreshUI()
+        {
+            var color = (Color)_property.Prop.GetValue(_property.Object);
+            if (_namedColorsReversed.ContainsKey(color.Value))
+            {
+                _text.Text = _namedColorsReversed[color.Value];
+            }
+            else
+            {
+                _text.Text = $"{color.R},{color.G},{color.B},{color.A}";
+            }
+            _colorLabel.Tint = color;
+            _text.Border = AGSBorders.SolidColor(color, 2f);
+            var buttonBorder = AGSBorders.Multiple(AGSBorders.SolidColor(color, 1f),
+                               _factory.Graphics.Icons.GetArrowIcon(ArrowDirection.Down, color));
+            _dropDownButton.IdleAnimation = new ButtonAnimation(buttonBorder, null, Colors.Transparent);
+            _dropDownButton.Border = buttonBorder;
+        }
+
+        private void onTextboxPressingKey(TextBoxKeyPressingEventArgs args)
+        {
+            string text = args.IntendedState.Text;
+            if (string.IsNullOrEmpty(text)) return;
+
+            //except for selecting pre-set colors from the dropdown, we'll allow multiple formats in the 
+            //textbox for specifying the color:
+            //1. "{R},{G},{B}" or "{R},{G},{B},{A}": those would be from 0-255
+            //2. "#{HEXA}" for a hexa color number
+
+            if (parseHexaColor(text)) return;
+            parseRgbColor(text, args);
+        }
+
+        private bool parseHexaColor(string text)
+        {
+            if (!text.StartsWith("#", StringComparison.Ordinal) || text.Length == 1) return false;
+
+            text = text.Substring(1);
+            if (text.Length == 6)
+            {
+                text = "ff" + text;
+            }
+            if (!uint.TryParse(text, NumberStyles.HexNumber, CultureInfo.InvariantCulture, out uint hexaColor)) return false;
+            _property.Prop.SetValue(_property.Object, Color.FromHexa(hexaColor));
+            return true;
+        }
+
+        private bool parseRgbColor(string text, TextBoxKeyPressingEventArgs args)
+        {
+            var tokens = text.Split(',');
+            if (tokens.Length != 3 && tokens.Length != 4) return false;
+            if (!byte.TryParse(tokens[0], out byte r)) return false;
+            if (!byte.TryParse(tokens[1], out byte g)) return false;
+            if (!byte.TryParse(tokens[2], out byte b)) return false;
+            byte a = 255;
+            if (tokens.Length == 4)
+            {
+                if (!byte.TryParse(tokens[3], out a)) return false;
+            }
+
+            var color = Color.FromRgba(r, g, b, a);
+            var newColor = manipulateRgb(color, tokens, text, args);
+            if (newColor != null)
+            {
+                color = newColor.Value;
+                if (tokens.Length == 4) args.IntendedState.Text = $"{color.R},{color.G},{color.B},{color.A}";
+                else args.IntendedState.Text = $"{color.R},{color.G},{color.B}";
+            }
+            _property.Prop.SetValue(_property.Object, color);
+            return true;
+        }
+
+        private Color? manipulateRgb(Color color, string[] tokens, string text, TextBoxKeyPressingEventArgs args)
+        {
+            if (args.PressedKey != Key.Down && args.PressedKey != Key.Up) return null;
+
+            int caret = args.IntendedState.CaretPosition;
+            int firstComma = text.IndexOf(',');
+            if (caret <= firstComma)
+            {
+                return Color.FromRgba(manipulateColorUnit(color.R, args), color.G, color.B, color.A);
+            }
+
+            int secondComma = nthIndexOfComma(text, 0, 2);
+            if (caret <= secondComma)
+            {
+                return Color.FromRgba(color.R, manipulateColorUnit(color.G, args), color.B, color.A);
+            }
+
+            if (tokens.Length == 4)
+            {
+                int thirdComma = nthIndexOfComma(text, 0, 3);
+                if (caret > thirdComma)
+                {
+                    return Color.FromRgba(color.R, color.G, color.B, manipulateColorUnit(color.A, args));
+                }
+            }
+            return Color.FromRgba(color.R, color.G, manipulateColorUnit(color.B, args), color.A);
+        }
+
+        private byte manipulateColorUnit(byte unit, TextBoxKeyPressingEventArgs args)
+        {
+            if (unit <= 0 && args.PressedKey == Key.Down) return unit;
+            if (unit >= 255 && args.PressedKey == Key.Up) return unit;
+            if (args.PressedKey == Key.Down) return (byte)(unit - 1);
+            return (byte)(unit + 1);
+        }
+
+        //https://stackoverflow.com/questions/186653/get-the-index-of-the-nth-occurrence-of-a-string
+        private static int nthIndexOfComma(string input, int startIndex, int nth)
+        {
+            if (nth < 1)
+                throw new NotSupportedException("Param 'nth' must be greater than 0!");
+            if (nth == 1)
+                return input.IndexOf(',', startIndex);
+            var idx = input.IndexOf(',', startIndex);
+            if (idx == -1)
+                return -1;
+            return nthIndexOfComma(input, idx + 1, nth - 1);
+        }
+    }
+}

--- a/Source/Engine/AGS.Engine/UI/DebugControls/DebugView/Inspector/InspectorPanel.cs
+++ b/Source/Engine/AGS.Engine/UI/DebugControls/DebugView/Inspector/InspectorPanel.cs
@@ -7,10 +7,12 @@ namespace AGS.Engine
     {
 		private readonly IRenderLayer _layer;
 		private readonly IGame _game;
-        private IPanel _panel, _scrollingPanel, _parent;
+        private IPanel _treePanel, _scrollingPanel, _contentsPanel, _parent;
         private ITextBox _searchBox;
         private InspectorTreeNodeProvider _inspectorNodeView;
+
         const float _padding = 42f;
+        const float _gutterSize = 15f;
 
         public InspectorPanel(IGame game, IRenderLayer layer)
         {
@@ -34,26 +36,27 @@ namespace AGS.Engine
             _searchBox.Pivot = new PointF(0f, 1f);
             _searchBox.GetComponent<ITextComponent>().PropertyChanged += onSearchPropertyChanged;
 
-            var height = parent.Height - _searchBox.Height;
-            _scrollingPanel = factory.UI.GetPanel("GameDebugInspectorScrollingPanel", parent.Width, height, 0f, height, parent);
+            var height = parent.Height - _searchBox.Height - _gutterSize;
+            _scrollingPanel = factory.UI.GetPanel("GameDebugInspectorScrollingPanel", parent.Width - _gutterSize, height, 0f, parent.Height - _searchBox.Height, parent);
 			_scrollingPanel.RenderLayer = _layer;
 			_scrollingPanel.Pivot = new PointF(0f, 1f);
 			_scrollingPanel.Tint = Colors.Transparent;
             _scrollingPanel.Border = AGSBorders.SolidColor(GameViewColors.Border, 2f);
+            _contentsPanel = factory.UI.CreateScrollingPanel(_scrollingPanel);
 
-            _panel = factory.UI.GetPanel("GameDebugInspectorPanel", parent.Width, _padding, 0f, height - _padding, _scrollingPanel);
-			_panel.Tint = Colors.Transparent;
-			_panel.RenderLayer = _layer;
-			var treeView = _panel.AddComponent<ITreeViewComponent>();
+            _treePanel = factory.UI.GetPanel("GameDebugInspectorPanel", 0f, 0f, 0f, _contentsPanel.Height - _padding, _contentsPanel);
+			_treePanel.Tint = Colors.Transparent;
+            _treePanel.RenderLayer = _layer;
+            _treePanel.Pivot = new PointF(0f, 1f);
+			var treeView = _treePanel.AddComponent<ITreeViewComponent>();
             treeView.SkipRenderingRoot = true;
 
             Inspector = new AGSInspector(_game.Factory, _game.Settings, _game.State);
-            _panel.AddComponent<IInspectorComponent>(Inspector);
-            factory.UI.CreateScrollingPanel(_scrollingPanel);
+            _treePanel.AddComponent<IInspectorComponent>(Inspector);
 
             _inspectorNodeView = new InspectorTreeNodeProvider(treeView.NodeViewProvider, _game.Factory, 
-                                                               _game.Events, _panel);
-            _inspectorNodeView.Resize(_parent.Width);
+                                                               _game.Events, _treePanel);
+            _inspectorNodeView.Resize(_contentsPanel.Width);
             treeView.NodeViewProvider = _inspectorNodeView;
 
             _parent.Bind<IScaleComponent>(c => c.PropertyChanged += onParentPanelScaleChanged,
@@ -62,19 +65,20 @@ namespace AGS.Engine
 
 		public void Resize()
 		{
-			_scrollingPanel.Image = new EmptyImage(_parent.Width, _scrollingPanel.Image.Height);
+            _contentsPanel.BaseSize = new SizeF(_parent.Width - _gutterSize, _contentsPanel.Height);
             _searchBox.LabelRenderSize = new SizeF(_parent.Width, _searchBox.Height);
             _searchBox.Watermark.LabelRenderSize = new SizeF(_parent.Width, _searchBox.Height);
-            _inspectorNodeView.Resize(_parent.Width);
+            _inspectorNodeView.Resize(_contentsPanel.Width);
 		}
 
         private void onParentPanelScaleChanged(object sender, PropertyChangedEventArgs args)
         {
             if (args.PropertyName != nameof(IScaleComponent.Height)) return;
-            _scrollingPanel.Image = new EmptyImage(_scrollingPanel.Image.Width, _parent.Height - _searchBox.Height);
+
+            _contentsPanel.BaseSize = new SizeF(_contentsPanel.Width, _parent.Height - _searchBox.Height - _gutterSize);
             _scrollingPanel.Y = _parent.Height - _searchBox.Height;
             _searchBox.Y = _parent.Height;
-            _panel.Y = _scrollingPanel.Height - _padding;
+            _treePanel.Y = _contentsPanel.Height;
         }
 
         private void onSearchPropertyChanged(object sender, PropertyChangedEventArgs e)

--- a/Source/Engine/AGS.Engine/UI/DebugControls/DebugView/Inspector/InspectorPanel.cs
+++ b/Source/Engine/AGS.Engine/UI/DebugControls/DebugView/Inspector/InspectorPanel.cs
@@ -78,7 +78,7 @@ namespace AGS.Engine
             _contentsPanel.BaseSize = new SizeF(_contentsPanel.Width, _parent.Height - _searchBox.Height - _gutterSize);
             _scrollingPanel.Y = _parent.Height - _searchBox.Height;
             _searchBox.Y = _parent.Height;
-            _treePanel.Y = _contentsPanel.Height;
+            _treePanel.Y = _contentsPanel.Height - _padding;
         }
 
         private void onSearchPropertyChanged(object sender, PropertyChangedEventArgs e)

--- a/Source/Engine/AGS.Engine/UI/DebugControls/DebugView/Inspector/InspectorProperty.cs
+++ b/Source/Engine/AGS.Engine/UI/DebugControls/DebugView/Inspector/InspectorProperty.cs
@@ -31,22 +31,29 @@ namespace AGS.Engine
 
 		public void Refresh()
 		{
-			object val = Prop.GetValue(Object);
-            if (val == null) Value = NullValue;
-            else
+            try
             {
-                var provider = _customValueProviders.GetOrAdd(Prop.PropertyType, () =>
+                object val = Prop.GetValue(Object);
+                if (val == null) Value = NullValue;
+                else
                 {
-                    var methods = Prop.PropertyType.GetRuntimeMethods();
-                    foreach (var candidate in methods)
+                    var provider = _customValueProviders.GetOrAdd(Prop.PropertyType, () =>
                     {
-                        var attr = candidate.GetCustomAttribute<CustomStringValueAttribute>();
-                        if (attr != null) return (candidate, attr);
-                    }
-                    return default;
-                });
-                MethodInfo method = getCustomStringMethod(provider);
-                Value = method == null ? val.ToString() : method.Invoke(val, null).ToString();
+                        var methods = Prop.PropertyType.GetRuntimeMethods();
+                        foreach (var candidate in methods)
+                        {
+                            var attr = candidate.GetCustomAttribute<CustomStringValueAttribute>();
+                            if (attr != null) return (candidate, attr);
+                        }
+                        return default;
+                    });
+                    MethodInfo method = getCustomStringMethod(provider);
+                    Value = method == null ? val.ToString() : method.Invoke(val, null).ToString();
+                }
+            }
+            catch (Exception e)
+            {
+                throw new Exception($"Failed to refresh property: {Name}", e);
             }
 		}
 

--- a/Source/Engine/AGS.Engine/UI/Text/GLLabelRenderer.cs
+++ b/Source/Engine/AGS.Engine/UI/Text/GLLabelRenderer.cs
@@ -125,8 +125,9 @@ namespace AGS.Engine
 
             if (_lastObject != obj)
             {
+                IBlockingEvent boxChangeEvent = obj.GetComponent<IBoundingBoxComponent>()?.OnBoundingBoxesChanged ?? new AGSEvent();
                 AGSBoundingBoxComponent box = new AGSBoundingBoxComponent(_settings, _viewport,
-                                                                          _labelBoundingBoxFakeBuilder, _state, _events);
+                                              _labelBoundingBoxFakeBuilder, _state, _events, boxChangeEvent);
                 obj.RemoveComponent<IBoundingBoxComponent>();
                 obj.AddComponent<IBoundingBoxComponent>(box);
                 _lastObject = obj;

--- a/Source/Engine/AGS.Engine/UI/Text/GLText.cs
+++ b/Source/Engine/AGS.Engine/UI/Text/GLText.cs
@@ -80,9 +80,10 @@ namespace AGS.Engine
               PointF? scaleUp = null, PointF? scaleDown = null, int caretPosition = 0, bool renderCaret = false,
               bool cropText = false, bool measureOnly = false)
         {
+            bool configIsDifferent = config != null && !config.Equals(_config);
             bool changeNeeded =
                 (text != null && text != _text)
-                || (config != null && !config.Equals(_config))
+                || configIsDifferent
                 || (maxWidth != null && maxWidth.Value != _maxWidth)
                 || !baseSize.Equals(_baseSize)
                 || _caretPosition != caretPosition
@@ -95,9 +96,9 @@ namespace AGS.Engine
             if (!changeNeeded) return false;
 
             _text = text;
-            if (config != null && config != _config)
+            if (configIsDifferent)
             {
-                _config = config;
+                _config = AGSTextConfig.Clone(config);
                 _spaceWidth = measureSpace();
             }
             if (maxWidth != null) _maxWidth = maxWidth.Value;

--- a/Source/Tests/Engine/ComponentsFramework/ComponentTests.cs
+++ b/Source/Tests/Engine/ComponentsFramework/ComponentTests.cs
@@ -1,0 +1,30 @@
+﻿using System;
+using System.ComponentModel;
+using AGS.API;
+using AGS.Engine;
+using Moq;
+using NUnit.Framework;
+
+namespace Tests
+{
+    [TestFixture]
+    public class ComponentTests
+    {
+        [Test]
+        public void ComponentPropertyChangedSubscription()
+        {
+            AGSSprite component = new AGSSprite(Mocks.GetResolver(), new Mock<IMaskLoader>().Object);
+            Assert.AreEqual(0, component.GetPropertyChangedSubscriberCount());
+
+            component.PropertyChanged += onComponentPropertyChanged;
+            Assert.AreEqual(1, component.GetPropertyChangedSubscriberCount());
+
+            component.PropertyChanged -= onComponentPropertyChanged;
+            Assert.AreEqual(0, component.GetPropertyChangedSubscriberCount());
+        }
+
+        private void onComponentPropertyChanged(object sender, PropertyChangedEventArgs e)
+        {
+        }
+    }
+}

--- a/Source/Tests/Tests.csproj
+++ b/Source/Tests/Tests.csproj
@@ -83,6 +83,7 @@
     <Compile Include="Engine\ComponentsFramework\ComponentBindingTests.cs" />
     <Compile Include="Engine\Misc\Collection\TreeNodeTests.cs" />
     <Compile Include="Engine\ComponentsFramework\EntityTests.cs" />
+    <Compile Include="Engine\ComponentsFramework\ComponentTests.cs" />
   </ItemGroup>
   <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
   <ItemGroup>


### PR DESCRIPTION
Resolves #172 

Added a color editor to the inspector.
The color editor has a drop-down to select between known colors, but also allows directly typing hexa colors, or RGB/RGBA colors. If typing in RGB/RGBA colors, one can use the up/down arrow keys to change R/G/B/A elements, depending on where the caret is standing.

See demo below (in very low resolution because of Github file size limits):
![color_editor](https://user-images.githubusercontent.com/1819001/36078790-27be2670-0f49-11e8-987b-36181a75aa3c.gif)

