### PR TITLE
Resource loading- refactored to have multiple resource packs

### DIFF
--- a/Source/AGS.API/AGS.API.csproj
+++ b/Source/AGS.API/AGS.API.csproj
@@ -270,6 +270,7 @@
     <Compile Include="UI\Layouts\TreeTable\ITreeTableLayout.cs" />
     <Compile Include="UI\Layouts\TreeTable\ITreeTableRowLayoutComponent.cs" />
     <Compile Include="UI\Layouts\TreeTable\QueryLayoutEventArgs.cs" />
+    <Compile Include="Misc\Resources\IResourcePack.cs" />
   </ItemGroup>
   <Import Project="$(MSBuildExtensionsPath32)\Microsoft\Portable\$(TargetFrameworkVersion)\Microsoft.Portable.CSharp.targets" />
   <ItemGroup />

--- a/Source/AGS.API/Misc/Resources/IResourceLoader.cs
+++ b/Source/AGS.API/Misc/Resources/IResourceLoader.cs
@@ -3,7 +3,11 @@
 namespace AGS.API
 {
     /// <summary>
-    /// There are 2 ways you can have resources in your game: 
+    /// The resource loader is the go-to place for retrieving resources.
+    /// It does so by querying various resources packs for the resource you require until it is found.
+    /// Each resource pack has a priority which determines the order of precedence in which the packs are queried (higher priority gets precedence).
+    /// 
+    /// There are currently 2 built-in resource packs in the engine, which allow for 2 ways you can have resources in your game: 
     /// They can be embedded in the project or loaded from the file system.
     /// This interface allows for loading resource either from the embedded project files or from the file system.
     /// 
@@ -30,35 +34,20 @@ namespace AGS.API
     /// searches for an embedded resource with that path, but if one is not found, it looks for the file in the 
     /// file system.
     /// </summary>
-    public interface IResourceLoader
+    public interface IResourceLoader : IResourcePack
 	{
         /// <summary>
-        /// Loads a resource from a embedded/file path.
+        /// Allows adding/removing resource packs from the resource loader.
         /// </summary>
-        /// <returns>The resource.</returns>
-        /// <param name="path">Path.</param>
-		IResource LoadResource(string path);
+        /// <value>The resource packs.</value>
+        IAGSBindingList<IResourcePack> ResourcePacks { get; }
 
         /// <summary>
         /// Loads a list of resources from a list of embedded/file paths.
         /// </summary>
         /// <returns>The resources.</returns>
         /// <param name="paths">Paths.</param>
-		List<IResource> LoadResources(params string[] paths);
-
-        /// <summary>
-        /// Loads all the the resource available in the specified embedded/file system folder.
-        /// </summary>
-        /// <returns>The resources.</returns>
-        /// <param name="folder">Folder.</param>
-		List<IResource> LoadResources(string folder);
-
-        /// <summary>
-        /// Finds a file/resource path for the specified path.
-        /// </summary>
-        /// <returns>The file/resource path if found a matching resource/file, otherwise null.</returns>
-        /// <param name="path">Path.</param>
-        string FindFilePath(string path);
+        List<IResource> LoadResourcesFromPaths(params string[] paths);
 	}
 }
 

--- a/Source/AGS.API/Misc/Resources/IResourceLoader.cs
+++ b/Source/AGS.API/Misc/Resources/IResourceLoader.cs
@@ -40,7 +40,7 @@ namespace AGS.API
         /// Allows adding/removing resource packs from the resource loader.
         /// </summary>
         /// <value>The resource packs.</value>
-        IAGSBindingList<IResourcePack> ResourcePacks { get; }
+        IAGSBindingList<ResourcePack> ResourcePacks { get; }
 
         /// <summary>
         /// Loads a list of resources from a list of embedded/file paths.
@@ -49,5 +49,35 @@ namespace AGS.API
         /// <param name="paths">Paths.</param>
         List<IResource> LoadResourcesFromPaths(params string[] paths);
 	}
+
+    /// <summary>
+    /// A resource pack to be registered with the resource loader. It carries both the resource pack implementation,
+    /// and a priority which used to decide which resource pack takes precedence in the resource loader (higher is better).
+    /// </summary>
+    public struct ResourcePack
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="T:AGS.API.ResourcePack"/> struct.
+        /// </summary>
+        /// <param name="pack">Pack.</param>
+        /// <param name="priority">Priority.</param>
+        public ResourcePack(IResourcePack pack, int priority)
+        {
+            Pack = pack;
+            Priority = priority;
+        }
+
+        /// <summary>
+        /// Gets the resource pack.
+        /// </summary>
+        /// <value>The resource pack.</value>
+        public IResourcePack Pack { get; private set; }
+
+        /// <summary>
+        /// Gets the priority.
+        /// </summary>
+        /// <value>The priority.</value>
+        public int Priority { get; private set; }
+    }
 }
 

--- a/Source/AGS.API/Misc/Resources/IResourcePack.cs
+++ b/Source/AGS.API/Misc/Resources/IResourcePack.cs
@@ -12,12 +12,6 @@ namespace AGS.API
     public interface IResourcePack
     {
         /// <summary>
-        /// Gets the priority of the pack which is used by the <see cref="IResourceLoader"/> for determining which resource pack is queried first (higher priority gets precedence).
-        /// </summary>
-        /// <value>The priority.</value>
-        int Priority { get; }
-
-        /// <summary>
         /// Loads a resource from a embedded/file path.
         /// </summary>
         /// <returns>The resource.</returns>

--- a/Source/AGS.API/Misc/Resources/IResourcePack.cs
+++ b/Source/AGS.API/Misc/Resources/IResourcePack.cs
@@ -1,0 +1,41 @@
+﻿using System;
+using System.Collections.Generic;
+
+namespace AGS.API
+{
+    /// <summary>
+    /// A resource pack is an abstract representation of a storage space for retrieving resources.
+    /// There can be a resource pack that's based on the file system, a resource pack which retrieves embedded resource in the game file itself,
+    /// a resource pack that downloads resources from the web, a resource pack based on a zip file, etc.
+    /// <seealso cref="IResourceLoader"/>
+    /// </summary>
+    public interface IResourcePack
+    {
+        /// <summary>
+        /// Gets the priority of the pack which is used by the <see cref="IResourceLoader"/> for determining which resource pack is queried first (higher priority gets precedence).
+        /// </summary>
+        /// <value>The priority.</value>
+        int Priority { get; }
+
+        /// <summary>
+        /// Loads a resource from a embedded/file path.
+        /// </summary>
+        /// <returns>The resource.</returns>
+        /// <param name="path">Path.</param>
+        IResource LoadResource(string path);
+
+        /// <summary>
+        /// Loads all the the resource available in the specified embedded/file system folder.
+        /// </summary>
+        /// <returns>The resources.</returns>
+        /// <param name="folder">Folder.</param>
+        List<IResource> LoadResources(string folder);
+
+        /// <summary>
+        /// Finds a matching resource pack specific path for the specified global resource path.
+        /// </summary>
+        /// <returns>The resource pack path if found a matching resource, otherwise null.</returns>
+        /// <param name="path">Path.</param>
+        string ResolvePath(string path);
+    }
+}

--- a/Source/Demo/DemoQuest/Program.cs
+++ b/Source/Demo/DemoQuest/Program.cs
@@ -27,8 +27,8 @@ namespace DemoGame
 
             game.Events.OnLoad.Subscribe(async () =>
             {
-                game.Factory.Resources.ResourcePacks.Add(new FileSystemResourcePack(AGSGame.Device.FileSystem));
-                game.Factory.Resources.ResourcePacks.Add(new EmbeddedResourcesPack(AGSGame.Device.Assemblies.EntryAssembly));
+                game.Factory.Resources.ResourcePacks.Add(new ResourcePack(new FileSystemResourcePack(AGSGame.Device.FileSystem), 0));
+                game.Factory.Resources.ResourcePacks.Add(new ResourcePack(new EmbeddedResourcesPack(AGSGame.Device.Assemblies.EntryAssembly), 1));
                 game.Factory.Fonts.InstallFonts("../../Assets/Fonts/pf_ronda_seven.ttf", "../../Assets/Fonts/Pixel_Berry_08_84_Ltd.Edition.TTF");
                 AGSGameSettings.DefaultSpeechFont = game.Factory.Fonts.LoadFontFromPath("../../Assets/Fonts/pf_ronda_seven.ttf", 14f, FontStyle.Regular);
                 AGSGameSettings.DefaultTextFont = game.Factory.Fonts.LoadFontFromPath("../../Assets/Fonts/Pixel_Berry_08_84_Ltd.Edition.TTF", 14f, FontStyle.Regular);

--- a/Source/Demo/DemoQuest/Program.cs
+++ b/Source/Demo/DemoQuest/Program.cs
@@ -27,6 +27,8 @@ namespace DemoGame
 
             game.Events.OnLoad.Subscribe(async () =>
             {
+                game.Factory.Resources.ResourcePacks.Add(new FileSystemResourcePack(AGSGame.Device.FileSystem));
+                game.Factory.Resources.ResourcePacks.Add(new EmbeddedResourcesPack(AGSGame.Device.Assemblies.EntryAssembly));
                 game.Factory.Fonts.InstallFonts("../../Assets/Fonts/pf_ronda_seven.ttf", "../../Assets/Fonts/Pixel_Berry_08_84_Ltd.Edition.TTF");
                 AGSGameSettings.DefaultSpeechFont = game.Factory.Fonts.LoadFontFromPath("../../Assets/Fonts/pf_ronda_seven.ttf", 14f, FontStyle.Regular);
                 AGSGameSettings.DefaultTextFont = game.Factory.Fonts.LoadFontFromPath("../../Assets/Fonts/Pixel_Berry_08_84_Ltd.Edition.TTF", 14f, FontStyle.Regular);

--- a/Source/Engine/AGS.Engine.Desktop/DesktopDevice.cs
+++ b/Source/Engine/AGS.Engine.Desktop/DesktopDevice.cs
@@ -10,7 +10,7 @@ namespace AGS.Engine.Desktop
         {
             FileSystem = new DesktopFileSystem();
             Assemblies = new DesktopAssemblies();
-            _fontFamilyLoader = new DesktopFontFamilyLoader(new ResourceLoader(FileSystem, Assemblies));
+            _fontFamilyLoader = new DesktopFontFamilyLoader(getResourceLoader());
             GraphicsBackend = new OpenGLBackend();
             BitmapLoader = new DesktopBitmapLoader(GraphicsBackend);
             BrushLoader = new DesktopBrushLoader();
@@ -36,5 +36,15 @@ namespace AGS.Engine.Desktop
         public IGraphicsBackend GraphicsBackend { get; }
 
         public IKeyboardState KeyboardState { get; }
+
+        private IResourceLoader getResourceLoader()
+        {
+            ResourceLoader resourceLoader = new ResourceLoader();
+            FileSystemResourcePack fileResourcePack = new FileSystemResourcePack(FileSystem);
+            EmbeddedResourcesPack embeddedResourcePack = new EmbeddedResourcesPack(Assemblies.EntryAssembly);
+            resourceLoader.ResourcePacks.Add(fileResourcePack);
+            resourceLoader.ResourcePacks.Add(embeddedResourcePack);
+            return resourceLoader;
+        }
     }
 }

--- a/Source/Engine/AGS.Engine.Desktop/DesktopDevice.cs
+++ b/Source/Engine/AGS.Engine.Desktop/DesktopDevice.cs
@@ -42,8 +42,8 @@ namespace AGS.Engine.Desktop
             ResourceLoader resourceLoader = new ResourceLoader();
             FileSystemResourcePack fileResourcePack = new FileSystemResourcePack(FileSystem);
             EmbeddedResourcesPack embeddedResourcePack = new EmbeddedResourcesPack(Assemblies.EntryAssembly);
-            resourceLoader.ResourcePacks.Add(fileResourcePack);
-            resourceLoader.ResourcePacks.Add(embeddedResourcePack);
+            resourceLoader.ResourcePacks.Add(new ResourcePack(fileResourcePack, 0));
+            resourceLoader.ResourcePacks.Add(new ResourcePack(embeddedResourcePack, 1));
             return resourceLoader;
         }
     }

--- a/Source/Engine/AGS.Engine/Game/Factories/AGSFontFactory.cs
+++ b/Source/Engine/AGS.Engine/Game/Factories/AGSFontFactory.cs
@@ -40,7 +40,7 @@ namespace AGS.Engine
         {
             return _installedFonts.GetOrAdd(resourcePath, _ => 
             {
-                string filePath = _resources.FindFilePath(resourcePath);
+                string filePath = _resources.ResolvePath(resourcePath);
                 if (filePath != null && _device.FileSystem.FileExists(filePath)) return filePath;
                 var resource = _resources.LoadResource(resourcePath);
                 if (resource == null) throw new NullReferenceException($"Failed to find font in path: {resourcePath}");

--- a/Source/Engine/AGS.Engine/Graphics/Logic/GLGraphicsFactory.cs
+++ b/Source/Engine/AGS.Engine/Graphics/Logic/GLGraphicsFactory.cs
@@ -93,13 +93,13 @@ namespace AGS.Engine
 		public IAnimation LoadAnimationFromFiles(IAnimationConfiguration animationConfig = null, ILoadImageConfig loadConfig = null, params string[] files)
 		{
             if (files.Length == 0) throw new InvalidOperationException("No files given to LoadAnimationFromFiles");
-			return loadAnimationFromResources(files[0], _resources.LoadResources(files), animationConfig, loadConfig);
+			return loadAnimationFromResources(files[0], _resources.LoadResourcesFromPaths(files), animationConfig, loadConfig);
 		}
 
 		public async Task<IAnimation> LoadAnimationFromFilesAsync(IAnimationConfiguration animationConfig = null, ILoadImageConfig loadConfig = null, params string [] files)
 		{
             if (files.Length == 0) throw new InvalidOperationException("No files given to LoadAnimationFromFilesAsync");
-			return await loadAnimationFromResourcesAsync(files[0], await Task.Run(() => _resources.LoadResources (files)), 
+			return await loadAnimationFromResourcesAsync(files[0], await Task.Run(() => _resources.LoadResourcesFromPaths(files)), 
 			                                             animationConfig, loadConfig);
 		}
 

--- a/Source/Engine/AGS.Engine/Misc/Resources/EmbeddedResourcesPack.cs
+++ b/Source/Engine/AGS.Engine/Misc/Resources/EmbeddedResourcesPack.cs
@@ -1,0 +1,118 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Reflection;
+using AGS.API;
+
+namespace AGS.Engine
+{
+    public class EmbeddedResourcesPack : IResourcePack
+    {
+        private Assembly _assembly;
+        private string _assemblyName;
+        private Dictionary<string, List<string>> _resourceFolders;
+
+        public EmbeddedResourcesPack(Assembly assembly, string customAssemblyName = null, int priority = 1)
+        {
+            Priority = priority;
+            _assembly = assembly;
+            _assemblyName = customAssemblyName ?? assembly?.GetName().Name;
+        }
+
+        public int Priority { get; private set; }
+
+        public static string AssetsFolder = "Assets";
+
+        public string ResolvePath(string path)
+        {
+            string folder = Path.GetDirectoryName(path);
+            string filename = Path.GetFileName(path).ToUpper();
+            if (filename.Contains(".")) return path;
+
+            //We're assuming we received a file/resource name without the extension: let's try to find a matching resource/file.
+            string folderResourceName = getResourceName(folder);
+            if (_resourceFolders.TryGetValue(folderResourceName, out var files))
+            {
+                var matchingResource = files.FirstOrDefault(f => f.ToUpperInvariant().Contains(filename));
+                if (matchingResource != null) return matchingResource;
+            }
+            return null;
+        }
+
+        public IResource LoadResource(string path)
+        {
+            string resourcePath = getResourceName(path);
+
+            return loadResource(resourcePath);
+        }
+
+        public List<IResource> LoadResources(string folder)
+        {
+            loadResourceFolders();
+
+            string folderResource = getResourceName(folder);
+            List<IResource> resources = new List<IResource>();
+            if (_resourceFolders.TryGetValue(folderResource, out var embeddedResources))
+            {
+                foreach (string resourceName in embeddedResources)
+                {
+                    IResource resource = loadResource(resourceName);
+                    if (resource == null) continue;
+                    resources.Add(resource);
+                }
+            }
+            return resources;
+        }
+
+        private IResource loadResource(string resourceName)
+        {
+            if (resourceName == null) return null;
+            Stream stream = _assembly.GetManifestResourceStream(resourceName);
+            if (stream == null) return null;
+            return new AGSResource(resourceName, stream);
+        }
+
+        private string getResourceName(string path)
+        {
+            try
+            {
+                int assetsIndex = path.IndexOf(AssetsFolder, StringComparison.Ordinal);
+                if (assetsIndex < 0) return null;
+                string resourcePath = path.Substring(assetsIndex);
+                resourcePath = resourcePath.Replace('/', '.').Replace('\\', '.');
+                resourcePath = $"{_assemblyName}.{resourcePath}";
+                return resourcePath;
+            }
+            catch (Exception e)
+            {
+                throw new ArgumentException("Invalid resource name: " + path ?? "null", e);
+            }
+        }
+
+        private void loadResourceFolders()
+        {
+            if (Repeat.OnceOnly("LoadResourceFolders"))
+            {
+                _resourceFolders = new Dictionary<string, List<string>>(50);
+                foreach (string name in _assembly.GetManifestResourceNames())
+                {
+                    string folder = getFolderName(name);
+                    if (folder == null) continue;
+                    _resourceFolders.GetOrAdd(folder, () => new List<string>(20)).Add(name);
+                }
+            }
+        }
+
+        private string getFolderName(string resource)
+        {
+            int lastDot = resource.LastIndexOf('.');
+            if (lastDot < 0) return null;
+            string folder = resource.Substring(0, lastDot);
+            lastDot = folder.LastIndexOf('.');
+            if (lastDot < 0) return null;
+            folder = folder.Substring(0, lastDot);
+            return folder;
+        }
+    }
+}

--- a/Source/Engine/AGS.Engine/Misc/Resources/EmbeddedResourcesPack.cs
+++ b/Source/Engine/AGS.Engine/Misc/Resources/EmbeddedResourcesPack.cs
@@ -13,14 +13,11 @@ namespace AGS.Engine
         private string _assemblyName;
         private Dictionary<string, List<string>> _resourceFolders;
 
-        public EmbeddedResourcesPack(Assembly assembly, string customAssemblyName = null, int priority = 1)
+        public EmbeddedResourcesPack(Assembly assembly, string customAssemblyName = null)
         {
-            Priority = priority;
             _assembly = assembly;
             _assemblyName = customAssemblyName ?? assembly?.GetName().Name;
         }
-
-        public int Priority { get; private set; }
 
         public static string AssetsFolder = "Assets";
 

--- a/Source/Engine/AGS.Engine/Misc/Resources/FileSystemResourcePack.cs
+++ b/Source/Engine/AGS.Engine/Misc/Resources/FileSystemResourcePack.cs
@@ -13,15 +13,12 @@ namespace AGS.Engine
         private readonly Func<string, List<string>> _getFilesInFolderFunc;
         private readonly IFileSystem _fileSystem;
 
-        public FileSystemResourcePack(IFileSystem fileSystem, int priority = 0)
+        public FileSystemResourcePack(IFileSystem fileSystem)
         {
             _fileSystem = fileSystem;
-            Priority = priority;
             _externalFolders = new Dictionary<string, List<string>>(10);
             _getFilesInFolderFunc = getFilesInFolder; //Caching delegate to avoid memory allocations in critical path
         }
-
-        public int Priority { get; private set; }
 
         public string ResolvePath(string path)
         {

--- a/Source/Engine/AGS.Engine/Misc/Resources/FileSystemResourcePack.cs
+++ b/Source/Engine/AGS.Engine/Misc/Resources/FileSystemResourcePack.cs
@@ -1,0 +1,80 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.IO;
+using System.Linq;
+using AGS.API;
+
+namespace AGS.Engine
+{
+    public class FileSystemResourcePack : IResourcePack
+    {
+        private Dictionary<string, List<string>> _externalFolders;
+        private readonly Func<string, List<string>> _getFilesInFolderFunc;
+        private readonly IFileSystem _fileSystem;
+
+        public FileSystemResourcePack(IFileSystem fileSystem, int priority = 0)
+        {
+            _fileSystem = fileSystem;
+            Priority = priority;
+            _externalFolders = new Dictionary<string, List<string>>(10);
+            _getFilesInFolderFunc = getFilesInFolder; //Caching delegate to avoid memory allocations in critical path
+        }
+
+        public int Priority { get; private set; }
+
+        public string ResolvePath(string path)
+        {
+            if (shouldIgnoreFile(path)) return null;
+            string folder = Path.GetDirectoryName(path);
+            string filename = Path.GetFileName(path).ToUpper();
+            if (filename.Contains(".")) return path;
+
+            //We're assuming we received a file name without the extension: let's try to find a matching resource/file.
+            var files = _externalFolders.GetOrAdd(folder, _getFilesInFolderFunc);
+            var matchingFile = files.FirstOrDefault(f => f.ToUpperInvariant().Contains(filename));
+            return matchingFile;
+        }
+
+        public IResource LoadResource(string path)
+        {
+            path = ResolvePath(path);
+            if (path == null) return null;
+
+            return loadFile(path);
+        }
+
+        public List<IResource> LoadResources(string folder)
+        {
+            List<IResource> resources = new List<IResource>();
+            foreach (var file in _fileSystem.GetFiles(folder))
+            {
+                var resource = LoadResource(file);
+                if (resource == null) continue;
+                resources.Add(resource);
+            }
+            return resources;
+        }
+
+        private List<string> getFilesInFolder(string folder)
+        {
+            return _fileSystem.GetFiles(folder).ToList();
+        }
+
+        private IResource loadFile(string path)
+        {
+            if (!_fileSystem.FileExists(path))
+            {
+                Debug.WriteLine("File system resource pack- failed to find resource at path: {0}", path);
+                return null;
+            }
+            return new AGSResource(path, _fileSystem.Open(path));
+        }
+
+        private bool shouldIgnoreFile(string path)
+        {
+            return path == null ||
+                path.EndsWith(".DS_Store", StringComparison.Ordinal); //Mac OS file
+        }
+    }
+}

--- a/Source/Engine/AGS.Engine/Misc/Resources/ResourceLoader.cs
+++ b/Source/Engine/AGS.Engine/Misc/Resources/ResourceLoader.cs
@@ -11,16 +11,13 @@ namespace AGS.Engine
         private readonly List<IResource> _emptyResources = new List<IResource>(1);
         private List<IResourcePack> _sortedResourcePacks = new List<IResourcePack>(1);
 
-        public ResourceLoader(int priority = 0)
+        public ResourceLoader()
 		{
-            ResourcePacks = new AGSBindingList<IResourcePack>(5);
-            ResourcePacks.OnListChanged.Subscribe(args => _sortedResourcePacks = ResourcePacks.OrderByDescending(r => r.Priority).ToList());
-            Priority = priority;
+            ResourcePacks = new AGSBindingList<ResourcePack>(5);
+            ResourcePacks.OnListChanged.Subscribe(args => _sortedResourcePacks = ResourcePacks.OrderByDescending(r => r.Priority).Select(r => r.Pack).ToList());
 		}
 
-        public IAGSBindingList<IResourcePack> ResourcePacks { get; private set; }
-
-        public int Priority { get; private set; }
+        public IAGSBindingList<ResourcePack> ResourcePacks { get; private set; }
 
 		public IResource LoadResource(string path)
 		{

--- a/Source/Engine/AGS.Engine/Misc/Resources/ResourceLoader.cs
+++ b/Source/Engine/AGS.Engine/Misc/Resources/ResourceLoader.cs
@@ -1,6 +1,4 @@
 ﻿using System;
-using System.IO;
-using System.Reflection;
 using System.Diagnostics;
 using AGS.API;
 using System.Collections.Generic;
@@ -10,43 +8,33 @@ namespace AGS.Engine
 {
 	public class ResourceLoader : IResourceLoader
 	{
-		private readonly Assembly _assembly;
-        private Dictionary<string, List<string>> _resourceFolders, _externalFolders;
-        private readonly IFileSystem _fileSystem;
         private readonly List<IResource> _emptyResources = new List<IResource>(1);
-        private readonly Func<string, List<string>> _getFilesInFolderFunc;
+        private List<IResourcePack> _sortedResourcePacks = new List<IResourcePack>(1);
 
-        public ResourceLoader(IFileSystem fileSystem, IAssemblies assemblies)
+        public ResourceLoader(int priority = 0)
 		{
-            _fileSystem = fileSystem;
-			_assembly = assemblies.EntryAssembly;
-            _externalFolders = new Dictionary<string, List<string>>(10);
-            _getFilesInFolderFunc = getFilesInFolder; //Caching delegate to avoid memory allocations in critical path
+            ResourcePacks = new AGSBindingList<IResourcePack>(5);
+            ResourcePacks.OnListChanged.Subscribe(args => _sortedResourcePacks = ResourcePacks.OrderByDescending(r => r.Priority).ToList());
+            Priority = priority;
 		}
 
-		public static string CustomAssemblyName;
-		public static string AssetsFolder = "Assets";
+        public IAGSBindingList<IResourcePack> ResourcePacks { get; private set; }
+
+        public int Priority { get; private set; }
 
 		public IResource LoadResource(string path)
 		{
             Debug.WriteLine("Loading resource from " + path ?? "null");
 			if (shouldIgnoreFile(path)) return null;
-            path = FindFilePath(path);
-            if (path == null) return null;
-
-			string resourcePath = getResourceName(path);
-
-			IResource resource = loadResource(resourcePath);
-
-			if (resource != null)
-			{
-				return resource;
-			}
-
-			return loadFile(path);
+            foreach (var pack in _sortedResourcePacks)
+            {
+                var resource = pack.LoadResource(path);
+                if (resource != null) return resource;
+            }
+            return null;
 		}
 
-		public List<IResource> LoadResources(params string[] paths)
+		public List<IResource> LoadResourcesFromPaths(params string[] paths)
 		{
             if (paths.Length == 0)
             {
@@ -72,63 +60,22 @@ namespace AGS.Engine
 		public List<IResource> LoadResources(string folder)
 		{
             Debug.WriteLine("Loading resources from folder " + folder);
-			loadResourceFolders();
-
-			HashSet<Asset> assets = new HashSet<Asset> ();
-			foreach (var file in _fileSystem.GetFiles(folder))
-			{
-				if (shouldIgnoreFile(file)) continue;
-				Asset asset = new Asset (getResourceName(file), file);
-				assets.Add(asset);
-			}
-
-			string folderResource = getResourceName(folder);
-			if (_resourceFolders.TryGetValue(folderResource, out var embeddedResources))
-			{
-				foreach (string resource in embeddedResources)
-				{
-					Asset asset = new Asset (resource, null);
-					assets.Add(asset);
-				}
-			}
-			List<IResource> resources = new List<IResource> (assets.Count);
-			foreach (var asset in assets.OrderBy(r => r.ResourceName))
-			{
-				IResource resource = loadResource(asset.ResourceName);
-				if (resource == null && asset.Filename != null)
-					resource = loadFile(asset.Filename);
-				if (resource == null)
-				{
-					Debug.WriteLine("Failed to load resource {0} from folder.", asset.ResourceName);
-					continue;
-				}
-				resources.Add(resource);
-			}
-			return resources;
+            foreach (var pack in _sortedResourcePacks)
+            {
+                var resources = pack.LoadResources(folder);
+                if ((resources?.Count ?? 0) > 0) return resources.OrderBy(r => r.ID).ToList();
+            }
+            return _emptyResources;
 		}
 
-        public string FindFilePath(string path)
+        public string ResolvePath(string path)
         {
-            string folder = Path.GetDirectoryName(path);
-            string filename = Path.GetFileName(path).ToUpper();
-            if (filename.Contains(".")) return path;
-
-            //We're assuming we received a file/resource name without the extension: let's try to find a matching resource/file.
-            string folderResourceName = getResourceName(folder);
-            if (_resourceFolders.TryGetValue(folderResourceName, out var files))
+            foreach (var pack in _sortedResourcePacks)
             {
-                var matchingResource = files.FirstOrDefault(f => f.ToUpperInvariant().Contains(filename));
-                if (matchingResource != null) return matchingResource;
+                var newPath = pack.ResolvePath(path);
+                if (!string.IsNullOrEmpty(newPath)) return newPath;
             }
-
-            files = _externalFolders.GetOrAdd(folder, _getFilesInFolderFunc);
-            var matchingFile = files.FirstOrDefault(f => f.ToUpperInvariant().Contains(filename));
-            return matchingFile;
-        }
-
-        private List<string> getFilesInFolder(string folder)
-        {
-            return _fileSystem.GetFiles(folder).ToList();
+            return null;
         }
 
 		private bool shouldIgnoreFile(string path)
@@ -136,99 +83,5 @@ namespace AGS.Engine
 			return path == null || 
                 path.EndsWith(".DS_Store", StringComparison.Ordinal); //Mac OS file
 		}
-
-		private IResource loadResource(string resourceName)
-		{
-			if (resourceName == null) return null;
-			Stream stream = _assembly.GetManifestResourceStream(resourceName);
-            if (stream == null) return null;
-			return new AGSResource (resourceName, stream);
-		}
-
-		private IResource loadFile(string path)
-		{
-            if (!_fileSystem.FileExists(path))
-            {
-                Debug.WriteLine("Failed to find resource at path: {0}", path);
-                return null;
-            }
-            return new AGSResource(path, _fileSystem.Open(path));
-		}
-
-		private string getResourceName(string path)
-		{
-			try
-			{
-				string assemblyName = CustomAssemblyName ?? _assembly.GetName().Name;
-                int assetsIndex = path.IndexOf(AssetsFolder, StringComparison.Ordinal);
-				if (assetsIndex < 0) return null;
-				string resourcePath = path.Substring(assetsIndex);
-				resourcePath = resourcePath.Replace('/', '.').Replace('\\', '.');
-				resourcePath = $"{assemblyName}.{resourcePath}";
-				return resourcePath;
-			}
-			catch (Exception e)
-			{
-				throw new ArgumentException ("Invalid resource name: " + path ?? "null", e);
-			}
-		}
-
-		private string getFolderName(string resource)
-		{
-            int lastDot = resource.LastIndexOf('.');
-            if (lastDot < 0) return null;
-            string folder = resource.Substring(0, lastDot);
-            lastDot = folder.LastIndexOf('.');
-            if (lastDot < 0) return null;
-            folder = folder.Substring(0, lastDot);
-            return folder;
-		}
-
-        private void loadResourceFolders()
-		{
-			if (Repeat.OnceOnly("LoadResourceFolders"))
-			{
-				_resourceFolders = new Dictionary<string, List<string>> (50);
-				foreach (string name in _assembly.GetManifestResourceNames())
-				{
-					string folder = getFolderName(name);
-                    if (folder == null) continue;
-					_resourceFolders.GetOrAdd(folder, () => new List<string> (20)).Add(name);
-				}
-			}
-		}
-
-		private class Asset : IEquatable<Asset>
-		{
-			public Asset(string resourceName, string filename)
-			{
-				ResourceName = resourceName;
-				Filename = filename;
-			}
-
-			public string ResourceName { get; private set; }
-			public string Filename { get; private set; }
-
-			public override bool Equals(object obj)
-			{
-				return Equals(obj as Asset);
-			}
-
-			#region IEquatable implementation
-
-			public bool Equals(Asset other)
-			{
-				if (other == null) return false;
-				return ResourceName == other.ResourceName;
-			}
-
-			public override int GetHashCode()
-			{
-				return ResourceName.GetHashCode();
-			}
-
-			#endregion
-		}
 	}
 }
-


### PR DESCRIPTION
Refactored the resource loader (based on suggestions from @ivan-mogilko
) to have multiple resource packs (and can be configured to add more).
The 2 existing functionalities of loading embedded resources and
loading resources from the file system were extracted into 2 built in
resource packs.