### PR TITLE
Suggestion: add methods to create and load bitmap from resource to IGraphicsFactory

### DIFF
--- a/Source/AGS.API/Graphics/Logic/IGraphicsFactory.cs
+++ b/Source/AGS.API/Graphics/Logic/IGraphicsFactory.cs
@@ -26,6 +26,28 @@ namespace AGS.API
 		ISprite GetSprite();
 
         /// <summary>
+        /// Creates an empty bitmap with the specified width and height (in pixels).
+        /// </summary>
+        /// <returns>The bitmap.</returns>
+        /// <param name="width">Width.</param>
+        /// <param name="height">Height.</param>
+        IBitmap GetBitmap(int width, int height);
+
+        /// <summary>
+        /// Loads a raw bitmap from a resource/file path (<see cref="IResourceLoader"/>).
+        /// </summary>
+        /// <returns>The bitmap.</returns>
+        /// <param name="filePath">File/resource path.</param>
+        IBitmap LoadBitmap(string filePath);
+
+        /// <summary>
+        /// Loads a raw bitmap asynchronously from a resource/file path (<see cref="IResourceLoader"/>).
+        /// </summary>
+        /// <returns>The bitmap.</returns>
+        /// <param name="filePath">File/resource path.</param>
+        Task<IBitmap> LoadBitmapAsync(string filePath);
+
+        /// <summary>
         /// Loads an image from a resource/file path (<see cref="IResourceLoader"/>).
         /// </summary>
         /// <returns>The image.</returns>


### PR DESCRIPTION
There does not seem to be a proper method in factory API to load raw bitmap from resource.
Not too often, but sometimes this may come handy, for instance if you want to use it as a logical mask, instead of displaying it on screen.
There is a method to load bitmap from the stream, but that would require additional manipulations. Also it is "hidden" in the IDevice factory, and took some time to find.

This is a suggestion to add three simple methods to the IGraphicsFactory : GetBitmap(w, h) (named in accordance to GetSprite, etc, idk if it's the best name), LoadBitmap(resource) and LoadBitmapAsync(resource). Implementation basically copies necessary parts of loadImage.