### PR TITLE
Fix compiler warnings

### DIFF
--- a/Source/AGS.API/AGS.API.csproj
+++ b/Source/AGS.API/AGS.API.csproj
@@ -9,6 +9,7 @@
     <RootNamespace>AGS.API</RootNamespace>
     <AssemblyName>AGS.API</AssemblyName>
     <TargetFrameworkVersion>v5.0</TargetFrameworkVersion>
+    <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>

--- a/Source/Demo/DemoQuest.Desktop/DemoQuest.Desktop.csproj
+++ b/Source/Demo/DemoQuest.Desktop/DemoQuest.Desktop.csproj
@@ -9,6 +9,7 @@
     <AssemblyName>DemoQuest.Desktop</AssemblyName>
     <TargetFrameworkVersion>v4.6.1</TargetFrameworkVersion>
     <TargetFrameworkProfile />
+    <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>

--- a/Source/Engine/AGS.Engine.Desktop/AGS.Engine.Desktop.csproj
+++ b/Source/Engine/AGS.Engine.Desktop/AGS.Engine.Desktop.csproj
@@ -9,6 +9,7 @@
     <AssemblyName>AGS.Engine.Desktop</AssemblyName>
     <TargetFrameworkVersion>v4.6.1</TargetFrameworkVersion>
     <TargetFrameworkProfile />
+    <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>

--- a/Source/Engine/AGS.Engine/AGS.Engine.csproj
+++ b/Source/Engine/AGS.Engine/AGS.Engine.csproj
@@ -2,6 +2,7 @@
   <PropertyGroup>
     <TargetFramework>netstandard1.6</TargetFramework>
     <PackageTargetFallback>$(PackageTargetFallback);portable-win+net45+wp8+win81+wpa8</PackageTargetFallback>
+    <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">
     <LangVersion>7.1</LangVersion>


### PR DESCRIPTION
Added auto generated binding redirects based on this link:
https://docs.microsoft.com/en-us/dotnet/framework/configure-apps/how-to-enable-and-disable-automatic-binding-redirection

This should help resolve conflicts between different versions of assemblies.