### PR TITLE
Suggestion: rename ISound.Seek to Position

### DIFF
--- a/Docs/articles/ags-cheat-sheet.md
+++ b/Docs/articles/ags-cheat-sheet.md
@@ -514,7 +514,7 @@ The equivalent in `MonoAGS` would be `ISound`. Both are returned when you're pla
 
 | AGS | MonoAGS | AGS Example | MonoAGS Example | Further notes
 |-----|---------|-------------|-----------------|-----------------------------------
-| Seek | Seek | `channel.Seek(milliseconds);` | `sound.Seek = seconds;` | Milliseconds in AGS, seconds in MonoAGS. In AGS the value is int meaning you can't get a lower resolution than milliseconds. In MonoAGS the value is float meaning you can go as low in resolution as the hardware understands.
+| Seek | Position | `channel.Seek(2500);` | `sound.Position = 2.5;` | Milliseconds in AGS, seconds in MonoAGS. In AGS the value is int meaning you can't get a lower resolution than milliseconds. In MonoAGS the value is float meaning you can go as low in resolution as the hardware understands.
 | SetRoomLocation | ? | `channel.SetRoomLocation(x,y);` | ? | MonoAGS has the concept of a sound emitter which automatically pans the sound based on the location in the room, and can set the volume based on volume-changing areas, but nothing currently specifically exists for volume based on distance from a character.
 | Stop | Stop | `channel.Stop();` | `sound.Stop();` |
 | ID | SourceID | `channel.ID` | `sound.SourceID` |
@@ -522,7 +522,7 @@ The equivalent in `MonoAGS` would be `ISound`. Both are returned when you're pla
 | LengthMs | Duration | `channel.LengthMs` | `sound.Duration` |
 | Panning | Panning | `channel.Panning = -100;` | `sound.Panning = -1;` | -100 - 100 in AGS, -1 - 1 in MonoAGS. In AGS the value is int (meaning you can only have 200 values) where in MonoAGS the value is float (when you can have a range as big as the hardware understands).
 | PlayingClip | ? | `channel.PlayingClip` | ? | This is critical in AGS due to the fact the channel might be playing a lot of clips in its lifetime. Much less important in `MonoAGS` as you can know which clip the sound is coming from, because you're playing that sound.
-| Position | Seek | `if (channel.Position == 0)` | `if (channel.Seek == 0)` | Milliseconds in AGS, seconds in MonoAGS
+| Position | Position | `if (channel.Position == 1500)` | `if (channel.Position == 1.5)` | Milliseconds in AGS, seconds in MonoAGS
 | Volume | Volume | `channel.Volume = 100;` | `sound.Volume = 1f;` | 0 - 100 in AGS, 0 - 1 in MonoAGS. In AGS the value is int (meaning you can only have 200 values) where in MonoAGS the value is float (when you can have a range as big as the hardware understands).
 
 Missing in AGS but exists in MonoAGS: Pitch, Asynchronous completion API, Pause/Resume, Rewind, IsPaused, IsLooping, IsValid.

--- a/Docs/articles/audio.md
+++ b/Docs/articles/audio.md
@@ -19,7 +19,7 @@ You can query an audio clip to see how many sounds for this clip (if any) are cu
 
 When you play an audio clip, you'll get back a sound. A sound is an "instance" of the audio clip which is playing right now. The same properties that you can set for an audio clip (volume, pitch, panning) can also be set for a sound, only those will affect just this current sound, not future sounds that will be played from the clip, and also you can change those properties over and over as the sound running to achieve effect (like gradually reducing the volume for a fade-out effect, for example).
 
-You can also pause/stop/resume a sound, rewind a sound to the beginning or set the sound to a specific position within the file (by changing the "seek").
+You can also pause/stop/resume a sound, rewind a sound to the beginning or set the sound to a specific position within the file (by changing the "Position" property).
 You can query and see whether the sound is looping or not and whether it's valid or not (an invalid sound might result if something is wrong with the user's computer and the engine was not able to play the sound).
 
 Lastly, you can query the sound to see if it was already completed, and asynchronously wait for the sound to complete playing.

--- a/Source/AGS.API/Audio/ISound.cs
+++ b/Source/AGS.API/Audio/ISound.cs
@@ -56,10 +56,10 @@ namespace AGS.API
 		Task Completed { get; }
 
 		/// <summary>
-		/// Gets or sets the seek (position within the sound) in seconds.
+		/// Gets or sets the playback position within the sound in seconds.
 		/// </summary>
-		/// <value>The seek.</value>
-		float Seek { get; set; }
+		/// <value>The position.</value>
+		float Position { get; set; }
 
         /// <summary>
         /// Pause this sound.

--- a/Source/Engine/AGS.Engine/Audio/ALSound.cs
+++ b/Source/Engine/AGS.Engine/Audio/ALSound.cs
@@ -120,7 +120,7 @@ namespace AGS.Engine
 
         public float Duration { get; private set; }
 
-		public float Seek
+		public float Position
 		{
 			get 
 			{


### PR DESCRIPTION
This is a proposal to rename ISound.Seek property to Position, as something that could be more recognizable ("seek" seem to refer to an action that changes position).
Although Audio backend interface has another meaning for "position", it is refered to as "Panning" in the ISound interface, so hopefully should not cause conflicts.