### PR TITLE
Implemented Duration property for IAudioClip and ISound

### DIFF
--- a/Docs/articles/ags-cheat-sheet.md
+++ b/Docs/articles/ags-cheat-sheet.md
@@ -519,7 +519,7 @@ The equivalent in `MonoAGS` would be `ISound`. Both are returned when you're pla
 | Stop | Stop | `channel.Stop();` | `sound.Stop();` |
 | ID | SourceID | `channel.ID` | `sound.SourceID` |
 | IsPlaying | HasCompleted | `if (!channel.IsPlaying)` | `if (sound.HasCompleted)` | If you want to check whether the sound you played completed playing, `MonoAGS` provides you with a better option: In AGS, `channel.IsPlaying` might return true even if your sound finished playing, because another sound is now being played on that channel.
-| LengthMs | ? | `channel.LengthMs` | ? |
+| LengthMs | Duration | `channel.LengthMs` | `sound.Duration` |
 | Panning | Panning | `channel.Panning = -100;` | `sound.Panning = -1;` | -100 - 100 in AGS, -1 - 1 in MonoAGS. In AGS the value is int (meaning you can only have 200 values) where in MonoAGS the value is float (when you can have a range as big as the hardware understands).
 | PlayingClip | ? | `channel.PlayingClip` | ? | This is critical in AGS due to the fact the channel might be playing a lot of clips in its lifetime. Much less important in `MonoAGS` as you can know which clip the sound is coming from, because you're playing that sound.
 | Position | Seek | `if (channel.Position == 0)` | `if (channel.Seek == 0)` | Milliseconds in AGS, seconds in MonoAGS

--- a/Source/AGS.API/Audio/ISoundProperties.cs
+++ b/Source/AGS.API/Audio/ISoundProperties.cs
@@ -1,10 +1,15 @@
 ﻿namespace AGS.API
 {
     /// <summary>
-    /// Allows to set the properties (volume, pitch, gain) of a sound/clip.
+    /// Allows to read or adjust the properties (volume, pitch, gain) of a sound/clip.
     /// </summary>
 	public interface ISoundProperties
 	{
+        /// <summary>
+        /// Gets duration of the sound in seconds.
+        /// </summary>
+        float Duration { get; }
+
 		/// <summary>
 		/// Gets or sets the volume.
 		/// The minimum volume is 0 (no volume).

--- a/Source/Engine/AGS.Engine/Audio/ALSound.cs
+++ b/Source/Engine/AGS.Engine/Audio/ALSound.cs
@@ -14,13 +14,14 @@ namespace AGS.Engine
 		private IAudioErrors _errors;
         private IAudioBackend _backend;
 
-        public ALSound(int source, float volume, float pitch, bool isLooping, float panning, 
+        public ALSound(int source, float duration, float volume, float pitch, bool isLooping, float panning, 
             IAudioErrors errors, IAudioBackend backend)
 		{
 			_tcs = new TaskCompletionSource<object> (null);
             _backend = backend;
 			_source = source;
 			_volume = volume;
+            Duration = duration;
 			_pitch = pitch;
 			_panning = panning;
 			IsLooping = isLooping;
@@ -116,6 +117,8 @@ namespace AGS.Engine
 				_errors.HasErrors();
 			}
 		}
+
+        public float Duration { get; private set; }
 
 		public float Seek
 		{


### PR DESCRIPTION
Added IAudioClip.Duration and ISound.Duration properties, telling total duration of the sound in seconds.

Notes:
1. In current implementation duration is calculated from the ISoundData when ALAudioClip is created.
This calculation will be only valid if the sample rate is known at that time. AFAIK some sound files may not have such value in the header, which leaves only an option to parse whole file. But since that is a rare case, hopefully we won't need to support this too soon.
2. Duration property is currently added to both ISound and IAudioClip directly. Then, I realized they already share ISoundProperties, but it seem to refer to sound modifications, so I am in doubts. Should I move it to ISoundProperties instead?