### PR TITLE
Set looping sound's task result when stopped by user

### DIFF
--- a/Source/Engine/AGS.Engine/Audio/ALSound.cs
+++ b/Source/Engine/AGS.Engine/Audio/ALSound.cs
@@ -80,6 +80,7 @@ namespace AGS.Engine
 			if (HasCompleted) return;
 			_backend.SourceStop(_source);
 			_errors.HasErrors();
+			_tcs.TrySetResult(null);
 		}
 
         public int SourceID => _source;


### PR DESCRIPTION
This sets ALSound's Task result when user explicitly calls Stop(), which fixes looping sounds not reporting completion when stopped that way.

For non-looping sounds Task result is being set right in Play() method, after finished waiting for the sound source. Which also happens if you call Stop(), so I believe same should happen when you call Stop() for looping sound too.

Note: not sure if it is necessary to check for "IsLooping" in Stop. If we don't, then there will be double _tcs.TrySetResult call for non-looping sounds, but that did not cause any issues when I tested it out.