### PR TITLE
Resolver- fix memory leak

### DIFF
--- a/Source/Engine/AGS.Engine/Misc/DependencyInjection/ResolveAnythingSource.cs
+++ b/Source/Engine/AGS.Engine/Misc/DependencyInjection/ResolveAnythingSource.cs
@@ -1,0 +1,141 @@
+﻿//Code adapted from: https://github.com/autofac/Autofac/blob/develop/src/Autofac/Features/ResolveAnything/AnyConcreteTypeNotAlreadyRegisteredSource.cs
+//Only difference, is that we're using "ExternallyOwned" when creating our builder, so that we can release it without relating it to the lifetime of the container.
+
+// This software is part of the Autofac IoC container
+// Copyright © 2011 Autofac Contributors
+// http://autofac.org
+//
+// Permission is hereby granted, free of charge, to any person
+// obtaining a copy of this software and associated documentation
+// files (the "Software"), to deal in the Software without
+// restriction, including without limitation the rights to use,
+// copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the
+// Software is furnished to do so, subject to the following
+// conditions:
+//
+// The above copyright notice and this permission notice shall be
+// included in all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+// EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+// OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+// NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+// HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+// WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+// FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+// OTHER DEALINGS IN THE SOFTWARE.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+using Autofac.Builder;
+using Autofac.Core;
+
+namespace AGS.Engine
+{
+    /// <summary>
+    /// Provides registrations on-the-fly for any concrete type not already registered with
+    /// the container.
+    /// </summary>
+    public class ResolveAnythingSource : IRegistrationSource
+    {
+        private readonly Func<Type, bool> _predicate;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="ResolveAnythingSource"/> class.
+        /// </summary>
+        public ResolveAnythingSource()
+            : this(t => true)
+        {
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="ResolveAnythingSource"/> class.
+        /// </summary>
+        /// <param name="predicate">A predicate that selects types the source will register.</param>
+        public ResolveAnythingSource(Func<Type, bool> predicate)
+        {
+            _predicate = predicate ?? throw new ArgumentNullException(nameof(predicate));
+        }
+
+        /// <summary>
+        /// Retrieve registrations for an unregistered service, to be used
+        /// by the container.
+        /// </summary>
+        /// <param name="service">The service that was requested.</param>
+        /// <param name="registrationAccessor">A function that will return existing registrations for a service.</param>
+        /// <returns>Registrations providing the service.</returns>
+        public IEnumerable<IComponentRegistration> RegistrationsFor(
+            Service service,
+            Func<Service, IEnumerable<IComponentRegistration>> registrationAccessor)
+        {
+            if (registrationAccessor == null)
+            {
+                throw new ArgumentNullException(nameof(registrationAccessor));
+            }
+
+            var ts = service as TypedService;
+            if (ts == null || ts.ServiceType == typeof(string))
+            {
+                return Enumerable.Empty<IComponentRegistration>();
+            }
+
+            var typeInfo = ts.ServiceType.GetTypeInfo();
+            if (!typeInfo.IsClass ||
+                typeInfo.IsSubclassOf(typeof(Delegate)) ||
+                typeInfo.IsAbstract ||
+                typeInfo.IsGenericTypeDefinition ||
+
+                !_predicate(ts.ServiceType) ||
+                registrationAccessor(service).Any())
+            {
+                return Enumerable.Empty<IComponentRegistration>();
+            }
+
+            if (typeInfo.IsGenericType)
+            {
+                foreach (var typeParameter in typeInfo.GenericTypeArguments)
+                {
+                    // Issue #855: If the generic type argument doesn't match the filter don't look for a registration.
+                    if (_predicate(typeParameter) && !registrationAccessor(new TypedService(typeParameter)).Any())
+                    {
+                        return Enumerable.Empty<IComponentRegistration>();
+                    }
+                }
+            }
+
+            var builder = RegistrationBuilder.ForType(ts.ServiceType).ExternallyOwned();
+            RegistrationConfiguration?.Invoke(builder);
+            return new[] { builder.CreateRegistration() };
+        }
+
+        /// <summary>
+        /// Gets a value indicating whether the registrations provided by this source are 1:1 adapters on top
+        /// of other components (I.e. like Meta, Func or Owned.)
+        /// </summary>
+        public bool IsAdapterForIndividualComponents => false;
+
+        /// <summary>
+        /// Gets or sets an expression used to configure generated registrations.
+        /// </summary>
+        /// <value>
+        /// A <see cref="System.Action{T}"/> that can be used to modify the behavior
+        /// of registrations that are generated by this source.
+        /// </value>
+        public Action<IRegistrationBuilder<object, ConcreteReflectionActivatorData, SingleRegistrationStyle>> RegistrationConfiguration { get; set; }
+
+        /// <summary>
+        /// Returns a <see cref="System.String"/> that represents the current <see cref="System.Object"/>.
+        /// </summary>
+        /// <returns>
+        /// A <see cref="System.String"/> that represents the current <see cref="System.Object"/>.
+        /// </returns>
+        /// <filterpriority>2</filterpriority>
+        public override string ToString()
+        {
+            return "Resolve Anything Source";
+        }
+    }
+}

--- a/Source/Engine/AGS.Engine/Misc/DependencyInjection/Resolver.cs
+++ b/Source/Engine/AGS.Engine/Misc/DependencyInjection/Resolver.cs
@@ -21,16 +21,16 @@ namespace AGS.Engine
 			}
 
 			Builder.RegisterAssemblyTypes(typeof(AGSGame).GetTypeInfo().Assembly).
-				Except<SpatialAStarPathFinder>().AsImplementedInterfaces();
+                   Except<SpatialAStarPathFinder>().AsImplementedInterfaces().ExternallyOwned();
 
             registerDevice(device);
 
-			Builder.RegisterType<GLImageRenderer>().As<IImageRenderer>();
-			Builder.RegisterType<AGSObject>().As<IObject>();
-			Builder.RegisterType<GLImage>().As<IImage>();
-			Builder.RegisterType<AGSDialogActions>().As<IDialogActions>();
-			Builder.RegisterType<AGSSayLocationProvider>().As<ISayLocationProvider>();
-            Builder.RegisterType<AGSTreeNodeViewProvider>().As<ITreeNodeViewProvider>();
+            RegisterType<GLImageRenderer, IImageRenderer>();
+            RegisterType<AGSObject, IObject>();
+            RegisterType<GLImage, IImage>();
+            RegisterType<AGSDialogActions, IDialogActions>();
+            RegisterType<AGSSayLocationProvider, ISayLocationProvider>();
+            RegisterType<AGSTreeNodeViewProvider, ITreeNodeViewProvider>();
 
 			Builder.RegisterType<AGSGameState>().SingleInstance().As<IGameState>();
 			Builder.RegisterType<AGSGame>().SingleInstance().As<IGame>();
@@ -58,26 +58,31 @@ namespace AGS.Engine
 
 			registerComponents();
 
-			Builder.RegisterType<AGSSprite>().As<ISprite>();
-            Builder.RegisterType<AGSBoundingBoxesBuilder>().As<IBoundingBoxBuilder>();
-            Builder.RegisterType<AGSTranslate>().As<ITranslate>();
-            Builder.RegisterType<AGSScale>().As<IScale>();
-            Builder.RegisterType<AGSRotate>().As<IRotate>();
-            Builder.RegisterType<AGSHasImage>().As<IHasImage>();
-            Builder.RegisterType<AGSEvent>().As<IEvent>();
-            Builder.RegisterType<AGSEvent>().As<IBlockingEvent>();
-            Builder.RegisterType<AGSRestrictionList>().As<IRestrictionList>();
+			RegisterType<AGSSprite, ISprite>();
+            RegisterType<AGSBoundingBoxesBuilder, IBoundingBoxBuilder>();
+            RegisterType<AGSTranslate, ITranslate>();
+            RegisterType<AGSScale, IScale>();
+            RegisterType<AGSRotate, IRotate>();
+            RegisterType<AGSHasImage, IHasImage>();
+            RegisterType<AGSEvent, IEvent>();
+            RegisterType<AGSEvent, IBlockingEvent>();
+            RegisterType<AGSRestrictionList, IRestrictionList>();
 
-			Builder.RegisterGeneric(typeof(AGSEvent<>)).As(typeof(IEvent<>));
-			Builder.RegisterGeneric(typeof(AGSEvent<>)).As(typeof(IBlockingEvent<>));
+            Builder.RegisterGeneric(typeof(AGSEvent<>)).As(typeof(IEvent<>)).ExternallyOwned();
+            Builder.RegisterGeneric(typeof(AGSEvent<>)).As(typeof(IBlockingEvent<>)).ExternallyOwned();
 
 			FastFingerChecker checker = new FastFingerChecker ();
 			Builder.RegisterInstance(checker);
 
-            Builder.RegisterSource(new AnyConcreteTypeNotAlreadyRegisteredSource());
+            Builder.RegisterSource(new ResolveAnythingSource());
 
             foreach (var action in _overrides) action(this);
 		}
+
+        public void RegisterType<TType, TInterface>()
+        {
+            Builder.RegisterType<TType>().As<TInterface>().ExternallyOwned();
+        }
 
         public static void Override(Action<Resolver> action)
         {
@@ -114,8 +119,8 @@ namespace AGS.Engine
 				if (!isComponent(type)) continue;
 				registerComponent(type);
 			}
-			Builder.RegisterType<VisibleProperty>().As<IVisibleComponent>();
-			Builder.RegisterType<EnabledProperty>().As<IEnabledComponent>();
+			RegisterType<VisibleProperty, IVisibleComponent>();
+			RegisterType<EnabledProperty, IEnabledComponent>();
 		}
 
 		private bool isComponent(TypeInfo type)
@@ -128,7 +133,7 @@ namespace AGS.Engine
 			foreach (var compInterface in type.ImplementedInterfaces)
 			{
 				if (compInterface == typeof(IComponent) || compInterface == typeof(IDisposable)) continue;
-				Builder.RegisterType(type.AsType()).As(compInterface);
+                Builder.RegisterType(type.AsType()).As(compInterface).ExternallyOwned();
 			}
 		}
 	}

--- a/Source/Tests/Engine/Misc/DependencyInjection/ResolverTests.cs
+++ b/Source/Tests/Engine/Misc/DependencyInjection/ResolverTests.cs
@@ -1,0 +1,79 @@
+﻿using System;
+using System.Runtime.CompilerServices;
+using System.Threading;
+using System.Threading.Tasks;
+using AGS.API;
+using AGS.Engine;
+using Autofac;
+using NUnit.Framework;
+
+namespace Tests
+{
+    [TestFixture]
+    public class ResolverTests
+    {
+        private class TestClass : IDisposable
+        {
+            public void Dispose()
+            {
+            }
+        }
+
+        [Test]
+        public async Task ResolverMemoryLeakOutsideObjectTest()
+        {
+            await testAllocation<TestClass>();
+        }
+
+        [Test]
+        public async Task ResolverMemoryLeakComponentInterfaceTest()
+        {
+            await testAllocation<ITranslateComponent>();
+        }
+
+        [Test]
+        public async Task ResolverMemoryLeakComponentImplementationTest()
+        {
+            await testAllocation<AGSTranslateComponent>();
+        }
+
+        [Test]
+        public async Task ResolverMemoryLeakInterfaceTest()
+        {
+            AGSGame.UIThreadID = Environment.CurrentManagedThreadId;
+            await testAllocation<ITexture>();
+        }
+
+        [Test]
+        public async Task ResolverMemoryLeakImplementationTest()
+        {
+            AGSGame.UIThreadID = Environment.CurrentManagedThreadId;
+            await testAllocation<GLTexture>();
+        }
+
+        private async Task testAllocation<TObj>() where TObj : class
+        {
+            Mocks mocks = new Mocks();
+            Resolver resolver = Mocks.GetResolver();
+            resolver.Build();
+
+            var myReference = resolver.Container.Resolve<TObj>();
+
+            //https://stackoverflow.com/questions/11417283/strange-weakreference-behavior-on-mono
+            var weakRef = alloc(myReference);
+            await Task.Delay(5);
+
+            myReference = null;
+
+            GC.Collect(2, GCCollectionMode.Forced, true, true);
+
+            Assert.IsFalse(weakRef.IsAlive);
+        }
+
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static WeakReference alloc(object o)
+        {
+            return new WeakReference(o);
+        }
+    }
+}

--- a/Source/Tests/Tests.csproj
+++ b/Source/Tests/Tests.csproj
@@ -84,6 +84,7 @@
     <Compile Include="Engine\Misc\Collection\TreeNodeTests.cs" />
     <Compile Include="Engine\ComponentsFramework\EntityTests.cs" />
     <Compile Include="Engine\ComponentsFramework\ComponentTests.cs" />
+    <Compile Include="Engine\Misc\DependencyInjection\ResolverTests.cs" />
   </ItemGroup>
   <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
   <ItemGroup>
@@ -112,5 +113,6 @@
   <ItemGroup>
     <Folder Include="Engine\ComponentsFramework\" />
     <Folder Include="Engine\Misc\Collection\" />
+    <Folder Include="Engine\Misc\DependencyInjection\" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
Using a new source in AutoFac's container which is externally owned to avoid the container keeping references in memory.

Fixes #181
As we found a workaround to the underlying issue we'll keep working with AutoFac for now.