### PR TITLE
Get camera target position in absolute coordinates from a bounding box

### DIFF
--- a/Source/AGS.API/Misc/Geometry/AGSBoundingBox.cs
+++ b/Source/AGS.API/Misc/Geometry/AGSBoundingBox.cs
@@ -38,6 +38,8 @@ namespace AGS.API
 			MaxX = max(bottomLeft.X, bottomRight.X, topLeft.X, topRight.X);
 			MinY = min(bottomLeft.Y, bottomRight.Y, topLeft.Y, topRight.Y);
 			MaxY = max(bottomLeft.Y, bottomRight.Y, topLeft.Y, topRight.Y);
+            
+            CenterPoint = new Vector3((MinX + MaxX) / 2, (MinY + MaxY) / 2, 0f);
 
             IsValid = !MathUtils.FloatEquals(MinX, MaxX) && !MathUtils.FloatEquals(MinY, MaxY);
 		}
@@ -52,6 +54,7 @@ namespace AGS.API
             MaxX = maxX;
             MinY = minY;
             MaxY = maxY;
+            CenterPoint = new Vector3((minX + maxX) / 2, (minY + maxY) / 2, 0f);
             IsValid = !MathUtils.FloatEquals(MinX, MaxX) && !MathUtils.FloatEquals(MinY, MaxY);
 		}
 
@@ -80,6 +83,12 @@ namespace AGS.API
         /// </summary>
         /// <value>The top right point.</value>
 		public Vector3 TopRight { get; }
+
+        /// <summary>
+        /// Gets the center point in a flat XY plane.
+        /// </summary>
+        /// <value>The center point.</value>
+        public Vector3 CenterPoint { get; }
 
         /// <summary>
         /// Gets the width.

--- a/Source/Engine/AGS.Engine/Rooms/Viewport/AGSCamera.cs
+++ b/Source/Engine/AGS.Engine/Rooms/Viewport/AGSCamera.cs
@@ -45,9 +45,10 @@ namespace AGS.Engine
 
 			setScale(target, viewport, resetPosition);
 
-			//todo: Allow control over which point in the target to follow
-			float targetX = target.X;//target.CenterPoint == null ? target.X : target.CenterPoint.X;
-			float targetY = target.Y;//target.CenterPoint == null ? target.Y : target.CenterPoint.Y;
+            //todo: Allow control over which point in the target to follow
+            Vector3 center = target.GetBoundingBoxes(viewport).HitTestBox.CenterPoint;
+            float targetX = center.X;
+            float targetY = center.Y;
 			float maxResolutionX = virtualResoution.Width / viewport.ScaleX;
 			float maxResolutionY = virtualResoution.Height / viewport.ScaleY;
             targetX = getTargetPos(targetX, roomLimits.X, roomLimits.Width, maxResolutionX);


### PR DESCRIPTION
This makes AGSCamera to retrieve target object's position in absolute room coordinates as opposed to just using IObject.X and .Y that could be local coordinates relative to object's parent.

**Known issues:**
I noticed that when going into scrolling room camera starts at position 0,0 during transition and switches to character only after transition ends. Perhaps hit box is not updated in time?