### PR TITLE
Brightness & Saturation

### DIFF
--- a/Source/AGS.API/AGS.API.csproj
+++ b/Source/AGS.API/AGS.API.csproj
@@ -277,6 +277,7 @@
     <Compile Include="Graphics\Textures\ITextureFactory.cs" />
     <Compile Include="Game\IRepeatedlyExecuteEventArgs.cs" />
     <Compile Include="Misc\Events\ClaimEventToken.cs" />
+    <Compile Include="Graphics\Effects\ISaturationEffectComponent.cs" />
   </ItemGroup>
   <Import Project="$(MSBuildExtensionsPath32)\Microsoft\Portable\$(TargetFrameworkVersion)\Microsoft.Portable.CSharp.targets" />
   <ItemGroup />
@@ -287,5 +288,6 @@
   <ItemGroup />
   <ItemGroup>
     <Folder Include="Graphics\Textures\" />
+    <Folder Include="Graphics\Effects\" />
   </ItemGroup>
 </Project>

--- a/Source/AGS.API/Editor/Attributes/NumberEditor/NumberEditorSliderAttribute.cs
+++ b/Source/AGS.API/Editor/Attributes/NumberEditor/NumberEditorSliderAttribute.cs
@@ -13,10 +13,12 @@ namespace AGS.API
         /// </summary>
         /// <param name="sliderMin">Slider minimum.</param>
         /// <param name="sliderMax">Slider max.</param>
-        public NumberEditorSliderAttribute(float sliderMin, float sliderMax)
+        /// <param name="step">The step when using the keyboard arrows to control the value.</param>
+        public NumberEditorSliderAttribute(float sliderMin, float sliderMax, float step = 1f)
         {
             SliderMin = sliderMin;
             SliderMax = sliderMax;
+            Step = step;
         }
 
         /// <summary>
@@ -30,5 +32,11 @@ namespace AGS.API
         /// </summary>
         /// <value>The slider max.</value>
         public float SliderMax { get; private set; }
+
+        /// <summary>
+        /// Gets the step when using the keyboard arrows to control the value.
+        /// </summary>
+        /// <value>The step.</value>
+        public float Step { get; private set; }
     }
 }

--- a/Source/AGS.API/Graphics/Effects/ISaturationEffectComponent.cs
+++ b/Source/AGS.API/Graphics/Effects/ISaturationEffectComponent.cs
@@ -1,0 +1,30 @@
+﻿namespace AGS.API
+{
+    /// <summary>
+    /// Allows adjusting the saturation of an entity/screen.
+    /// If added as a component to an entity, the saturation property will control the entity's saturation.
+    /// If created separately (and initialized with a null entity), this can be use to control the saturation of the entire screen.
+    /// <example>
+    /// <code language="lang-csharp">
+    /// 
+    /// //to adjust saturation for an object:
+    /// myObj.AddComponent<ISaturationEffectComponent>().Saturation = 0.5f;
+    /// 
+    /// //to adjust saturation for the screen:
+    /// var effect = new SaturationEffect(game.Factory.Shaders, game.Events);
+    /// effect.Init(null);
+    /// effect.Saturation = 0.5f;
+    /// </code>
+    /// </example>
+    /// </summary>
+    public interface ISaturationEffectComponent : IComponent
+    {
+        /// <summary>
+        /// Gets or sets the saturation for the entity/screen.
+        /// The default is 1, which is the same color as the original image.
+        /// A lower value than 1 will reduce saturation (0 being completely gray) and a greater value than 1 will increase saturation. 
+        /// </summary>
+        /// <value>The saturation.</value>
+        float Saturation { get; set; }
+    }
+}

--- a/Source/AGS.API/Graphics/IImageComponent.cs
+++ b/Source/AGS.API/Graphics/IImageComponent.cs
@@ -26,6 +26,17 @@ namespace AGS.API
         Color Tint { get; set; }
 
         /// <summary>
+        /// Gets or sets the brightness of the object.
+        /// This is an additional modifier to the tint (<see cref="Tint"/>), which allows you to reach brighter
+        /// colors than the original image.
+        /// The brightness has 4 components to allow modifying each of the 4 RGBA components of the original color.
+        /// By default it's (1,1,1,1), meaning no changes to the original image.
+        /// To make the object twice as bright, set Brightness = new Vector4(2,2,2,2), or simply: new Vector4(2).
+        /// </summary>
+        /// <value>The brightness.</value>
+        Vector4 Brightness { get; set; }
+
+        /// <summary>
         /// Gets or sets the pivot point from which the position, scale and rotation are determined. 
         /// For example, rotating an image from its center point will rotate it in place, 
         /// while rotating it from its bottom-left point will rotate the entire image around the bottom-left. 

--- a/Source/AGS.API/UI/Layouts/TreeTable/ITreeTableRowLayoutComponent.cs
+++ b/Source/AGS.API/UI/Layouts/TreeTable/ITreeTableRowLayoutComponent.cs
@@ -1,5 +1,4 @@
-﻿using System;
-namespace AGS.API
+﻿namespace AGS.API
 {
     /// <summary>
     /// Represents a row in a tree view that aligns its columns with other rows, based on <see cref="ITreeTableLayout"/> .
@@ -11,5 +10,11 @@ namespace AGS.API
         /// </summary>
         /// <value>The table layout.</value>
         ITreeTableLayout Table { get; set; }
+
+        /// <summary>
+        /// Allows disabling specific entities from changing the overall aligned columns.
+        /// </summary>
+        /// <value>The restriction list.</value>
+        IRestrictionList RestrictionList { get; }
     }
 }

--- a/Source/Demo/DemoQuest/Characters/Cris.cs
+++ b/Source/Demo/DemoQuest/Characters/Cris.cs
@@ -27,7 +27,7 @@ namespace DemoGame
             approach.ApproachStyle.ApproachWhenVerb["Talk"] = ApproachHotspots.WalkIfHaveWalkPoint;
 			emitter.Object = _character;
 
-
+            _character.AddComponent<ISaturationEffectComponent>();
             //Uncomment for portrait
             /*
             var portrait = game.Factory.Object.GetObject("CrisPortrait");

--- a/Source/Demo/DemoQuest/GUI/FeaturesWindow/FeaturesTweenPanel.cs
+++ b/Source/Demo/DemoQuest/GUI/FeaturesWindow/FeaturesTweenPanel.cs
@@ -47,6 +47,7 @@ namespace DemoGame
                     ( "Red", () => o.TweenRed(0, time, ease())),
                     ( "Green", () => o.TweenGreen(255, time, ease())),
                     ( "Blue", () => o.TweenBlue(255, time, ease())),
+                    ( "Brightness", () => o.TweenBrightness(3f, time, ease())),
                     ( "Hue", () => o.TweenHue(360, time, ease())),
                     ( "Saturation", () => o.TweenSaturation(0f, time, ease())),
                     ( "Lightness", () => o.TweenLightness(0f, time, ease())),

--- a/Source/Demo/DemoQuest/GUI/FeaturesWindow/FeaturesTweenPanel.cs
+++ b/Source/Demo/DemoQuest/GUI/FeaturesWindow/FeaturesTweenPanel.cs
@@ -48,9 +48,10 @@ namespace DemoGame
                     ( "Green", () => o.TweenGreen(255, time, ease())),
                     ( "Blue", () => o.TweenBlue(255, time, ease())),
                     ( "Brightness", () => o.TweenBrightness(3f, time, ease())),
-                    ( "Hue", () => o.TweenHue(360, time, ease())),
-                    ( "Saturation", () => o.TweenSaturation(0f, time, ease())),
-                    ( "Lightness", () => o.TweenLightness(0f, time, ease())),
+                    ( "Tint Hue", () => o.TweenTintHue(360, time, ease())),
+                    ( "Tint Saturation", () => o.TweenTintSaturation(0f, time, ease())),
+                    ( "Tint Lightness", () => o.TweenTintLightness(0f, time, ease())),
+                    ( "Saturation", () => o.AddComponent<ISaturationEffectComponent>().TweenSaturation(0f, time, ease())),
                     ( "ScaleX", () => o.TweenScaleX(2f, time, ease())),
                     ( "ScaleY", () => o.TweenScaleY(2f, time, ease())),
                     ( "PivotX", () => o.TweenPivotX(1f, time, ease())),
@@ -104,6 +105,12 @@ namespace DemoGame
                         ( "ProjectHeight", () => viewport.TweenProjectHeight(0.5f, time, ease())),
                         ( "PivotX", () => viewport.TweenPivotX(0.5f, time, ease())),
                         ( "PivotY", () => viewport.TweenPivotY(0.5f, time, ease())),
+                        ( "Saturation", () => //maybe we should a "Screen" target and put the saturation tween there
+                            {
+                                SaturationEffectComponent effect = new SaturationEffectComponent(game.Factory.Shaders, game.Events);
+                                effect.Init(null);
+                                return effect.TweenSaturation(0f, time, ease());
+                        })
                     }
                 },
                 { "Music", new List<(string, Func<Tween>)>{

--- a/Source/Engine/AGS.Engine/ComponentsFramework/Templates/AGSButton.generated.cs
+++ b/Source/Engine/AGS.Engine/ComponentsFramework/Templates/AGSButton.generated.cs
@@ -392,6 +392,12 @@ namespace AGS.Engine
             set { _imageComponent.Tint = value; } 
         }
 
+        public Vector4 Brightness
+        {
+            get { return _imageComponent.Brightness; }
+            set { _imageComponent.Brightness = value; }
+        }
+
         public PointF Pivot 
         {  
             get { return _imageComponent.Pivot; }  

--- a/Source/Engine/AGS.Engine/ComponentsFramework/Templates/AGSCharacter.generated.cs
+++ b/Source/Engine/AGS.Engine/ComponentsFramework/Templates/AGSCharacter.generated.cs
@@ -329,6 +329,12 @@ namespace AGS.Engine
             set { _imageComponent.Tint = value; } 
         }
 
+        public Vector4 Brightness
+        {
+            get { return _imageComponent.Brightness; }
+            set { _imageComponent.Brightness = value; }
+        }
+
         public PointF Pivot 
         {  
             get { return _imageComponent.Pivot; }  

--- a/Source/Engine/AGS.Engine/ComponentsFramework/Templates/AGSCheckbox.generated.cs
+++ b/Source/Engine/AGS.Engine/ComponentsFramework/Templates/AGSCheckbox.generated.cs
@@ -389,6 +389,12 @@ namespace AGS.Engine
             set { _imageComponent.Tint = value; } 
         }
 
+        public Vector4 Brightness
+        {
+            get { return _imageComponent.Brightness; }
+            set { _imageComponent.Brightness = value; }
+        }
+
         public PointF Pivot 
         {  
             get { return _imageComponent.Pivot; }  

--- a/Source/Engine/AGS.Engine/ComponentsFramework/Templates/AGSComboBox.generated.cs
+++ b/Source/Engine/AGS.Engine/ComponentsFramework/Templates/AGSComboBox.generated.cs
@@ -428,6 +428,12 @@ namespace AGS.Engine
             set { _imageComponent.Tint = value; } 
         }
 
+        public Vector4 Brightness
+        {
+            get { return _imageComponent.Brightness; }
+            set { _imageComponent.Brightness = value; }
+        }
+
         public PointF Pivot 
         {  
             get { return _imageComponent.Pivot; }  

--- a/Source/Engine/AGS.Engine/ComponentsFramework/Templates/AGSInventoryWindow.generated.cs
+++ b/Source/Engine/AGS.Engine/ComponentsFramework/Templates/AGSInventoryWindow.generated.cs
@@ -389,6 +389,12 @@ namespace AGS.Engine
             set { _imageComponent.Tint = value; } 
         }
 
+        public Vector4 Brightness
+        {
+            get { return _imageComponent.Brightness; }
+            set { _imageComponent.Brightness = value; }
+        }
+
         public PointF Pivot 
         {  
             get { return _imageComponent.Pivot; }  

--- a/Source/Engine/AGS.Engine/ComponentsFramework/Templates/AGSLabel.generated.cs
+++ b/Source/Engine/AGS.Engine/ComponentsFramework/Templates/AGSLabel.generated.cs
@@ -433,6 +433,12 @@ namespace AGS.Engine
             set { _imageComponent.Tint = value; } 
         }
 
+        public Vector4 Brightness
+        {
+            get { return _imageComponent.Brightness; }
+            set { _imageComponent.Brightness = value; }
+        }
+
         public PointF Pivot 
         {  
             get { return _imageComponent.Pivot; }  

--- a/Source/Engine/AGS.Engine/ComponentsFramework/Templates/AGSObject.generated.cs
+++ b/Source/Engine/AGS.Engine/ComponentsFramework/Templates/AGSObject.generated.cs
@@ -316,6 +316,12 @@ namespace AGS.Engine
             set { _imageComponent.Tint = value; } 
         }
 
+        public Vector4 Brightness
+        {
+            get { return _imageComponent.Brightness; }
+            set { _imageComponent.Brightness = value; }
+        }
+
         public PointF Pivot 
         {  
             get { return _imageComponent.Pivot; }  

--- a/Source/Engine/AGS.Engine/ComponentsFramework/Templates/AGSPanel.generated.cs
+++ b/Source/Engine/AGS.Engine/ComponentsFramework/Templates/AGSPanel.generated.cs
@@ -386,6 +386,12 @@ namespace AGS.Engine
             set { _imageComponent.Tint = value; } 
         }
 
+        public Vector4 Brightness
+        {
+            get { return _imageComponent.Brightness; }
+            set { _imageComponent.Brightness = value; }
+        }
+
         public PointF Pivot 
         {  
             get { return _imageComponent.Pivot; }  

--- a/Source/Engine/AGS.Engine/ComponentsFramework/Templates/AGSSlider.generated.cs
+++ b/Source/Engine/AGS.Engine/ComponentsFramework/Templates/AGSSlider.generated.cs
@@ -463,6 +463,12 @@ namespace AGS.Engine
             set { _imageComponent.Tint = value; } 
         }
 
+        public Vector4 Brightness
+        {
+            get { return _imageComponent.Brightness; }
+            set { _imageComponent.Brightness = value; }
+        }
+
         public PointF Pivot 
         {  
             get { return _imageComponent.Pivot; }  

--- a/Source/Engine/AGS.Engine/ComponentsFramework/Templates/AGSTextbox.generated.cs
+++ b/Source/Engine/AGS.Engine/ComponentsFramework/Templates/AGSTextbox.generated.cs
@@ -392,6 +392,12 @@ namespace AGS.Engine
             set { _imageComponent.Tint = value; } 
         }
 
+        public Vector4 Brightness
+        {
+            get { return _imageComponent.Brightness; }
+            set { _imageComponent.Brightness = value; }
+        }
+
         public PointF Pivot 
         {  
             get { return _imageComponent.Pivot; }  

--- a/Source/Engine/AGS.Engine/Graphics/AGSSprite.cs
+++ b/Source/Engine/AGS.Engine/Graphics/AGSSprite.cs
@@ -136,6 +136,9 @@ namespace AGS.Engine
         [DoNotNotify]
         public Color Tint { get => _hasImage.Tint; set => _hasImage.Tint = value; }
 
+        [DoNotNotify]
+        public Vector4 Brightness { get => _hasImage.Brightness; set => _hasImage.Brightness = value; }
+
         public IArea PixelPerfectHitTestArea => Image == null ? null : _pixelPerfectArea.Value;
 
         #endregion

--- a/Source/Engine/AGS.Engine/Graphics/Effects/SaturationEffectComponent.cs
+++ b/Source/Engine/AGS.Engine/Graphics/Effects/SaturationEffectComponent.cs
@@ -1,0 +1,83 @@
+﻿using AGS.API;
+
+namespace AGS.Engine
+{
+    [RequiredComponent(typeof(IShaderComponent))]
+    public class SaturationEffectComponent : AGSComponent, ISaturationEffectComponent
+    {
+        public const string SATURATION_FRAGMENT_SHADER =
+            @"#version 120
+#ifdef GL_ES
+            precision mediump float;
+#endif
+            uniform sampler2D uTexture;
+            varying vec4 vColor;
+#ifdef GL_ES
+            varying vec2 vTexCoord;
+#endif
+
+            uniform float adjustment;
+
+            void main()
+            {
+#ifndef GL_ES
+                vec2 vTexCoord = gl_TexCoord[0].xy;
+#endif
+                vec4 col = texture2D(uTexture, vTexCoord) * vColor;
+
+                vec3 rgb = col.xyz;
+
+                //code from: https://github.com/AnalyticalGraphicsInc/cesium/blob/master/Source/Shaders/Builtin/Functions/saturation.glsl
+                const vec3 luminance = vec3(0.2125, 0.7154, 0.0721);
+                vec3 intensity = vec3(dot(rgb, luminance));
+                col.xyz = mix(intensity, rgb, adjustment);
+
+                gl_FragColor = col * vColor;
+            }";
+
+        private IShader _shader;
+        private IShaderComponent _target;
+        private readonly IShaderFactory _factory;
+        private readonly IGameEvents _events;
+
+        public SaturationEffectComponent(IShaderFactory factory, IGameEvents events)
+        {
+            _factory = factory;
+            _events = events;
+        }
+
+        [NumberEditorSlider(sliderMin: -2f, sliderMax: 2f, step: 0.1f)]
+        public float Saturation { get; set; } = 1f;
+
+		public override void Init(IEntity entity)
+		{
+            base.Init(entity);
+            _shader = _factory.FromText(null, SATURATION_FRAGMENT_SHADER);
+            if (entity != null)
+            {
+                entity.Bind<IShaderComponent>(c => { _target = c; c.Shader = _shader; }, _ => _shader = null);
+            }
+            else AGSGame.Shader = _shader;
+            _events.OnBeforeRender.Subscribe(onBeforeRender);
+		}
+
+        private IShader getActiveShader()
+        {
+            return _target?.Shader ?? AGSGame.Shader;
+        }
+
+		private void onBeforeRender()
+        {
+            var shader = _shader;
+            if (shader != null) shader = shader.Compile();
+            if (shader == null || shader != getActiveShader())
+            {
+                _shader = null;
+                AGSGame.Game.Events.OnBeforeRender.Unsubscribe(onBeforeRender);
+                return;
+            }
+            shader.Bind();
+            shader.SetVariable("adjustment", Saturation);
+        }
+    }
+}

--- a/Source/Engine/AGS.Engine/Graphics/Effects/ShakeEffect.cs
+++ b/Source/Engine/AGS.Engine/Graphics/Effects/ShakeEffect.cs
@@ -38,14 +38,14 @@ namespace AGS.Engine
     }
 ";
 
-		private readonly IObject _target;
+        private readonly IShaderComponent _target;
 		private readonly float _decay;
 		private float _strength;
 
 		private IShader _shakeShader, _previousShader;
 		private TaskCompletionSource<object> _taskCompletionSource;
 
-        public ShakeEffect(float strength = 0.05f, float decay = 0.99f, IObject target = null)
+        public ShakeEffect(float strength = 0.05f, float decay = 0.99f, IShaderComponent target = null)
 		{
 			_target = target;
 			_strength = strength;

--- a/Source/Engine/AGS.Engine/Graphics/Image/AGSHasImage.cs
+++ b/Source/Engine/AGS.Engine/Graphics/Image/AGSHasImage.cs
@@ -9,6 +9,7 @@ namespace AGS.Engine
         {
             Pivot = new PointF(0.5f, 0f);
             Tint = Colors.White;
+            Brightness = new Vector4(1f);
         }
 
         public byte Opacity
@@ -18,6 +19,8 @@ namespace AGS.Engine
         }
 
         public Color Tint { get; set; }
+
+        public Vector4 Brightness { get; set; }
 
         public PointF Pivot { get; set; }
 

--- a/Source/Engine/AGS.Engine/Graphics/Image/AGSImageComponent.cs
+++ b/Source/Engine/AGS.Engine/Graphics/Image/AGSImageComponent.cs
@@ -56,6 +56,8 @@ namespace AGS.Engine
 
         public Color Tint { get => _image.Tint; set => _image.Tint = value; }
 
+        public Vector4 Brightness { get => _image.Brightness; set => _image.Brightness = value; }
+
         public ISprite Sprite { get => _sprite; }
 
         public ISprite CurrentSprite { get => _provider?.Sprite; }

--- a/Source/Engine/AGS.Engine/Graphics/Image/AGSImageComponent.cs
+++ b/Source/Engine/AGS.Engine/Graphics/Image/AGSImageComponent.cs
@@ -56,6 +56,7 @@ namespace AGS.Engine
 
         public Color Tint { get => _image.Tint; set => _image.Tint = value; }
 
+        [NumberEditorSlider(sliderMin: 0f, sliderMax: 2f, step: 0.1f)]
         public Vector4 Brightness { get => _image.Brightness; set => _image.Brightness = value; }
 
         public ISprite Sprite { get => _sprite; }

--- a/Source/Engine/AGS.Engine/Graphics/Logic/GLColor.cs
+++ b/Source/Engine/AGS.Engine/Graphics/Logic/GLColor.cs
@@ -36,10 +36,10 @@ namespace AGS.Engine
 
 		public IGLColor Build(params IHasImage[] sprites)
 		{
-			R = multiply (s => s.Tint.R / COLOR_FACTOR, sprites);
-			G = multiply (s => s.Tint.G / COLOR_FACTOR, sprites);
-			B = multiply (s => s.Tint.B / COLOR_FACTOR, sprites);
-			A = multiply (s => s.Opacity / COLOR_FACTOR, sprites);
+            R = multiply(s => (s.Tint.R / COLOR_FACTOR) * s.Brightness.X, sprites);
+            G = multiply(s => (s.Tint.G / COLOR_FACTOR) * s.Brightness.Y, sprites);
+            B = multiply(s => (s.Tint.B / COLOR_FACTOR) * s.Brightness.Z, sprites);
+            A = multiply(s => (s.Opacity / COLOR_FACTOR) * s.Brightness.W, sprites);
 			return this;
 		}
 

--- a/Source/Engine/AGS.Engine/Misc/Tweening/Tweens.cs
+++ b/Source/Engine/AGS.Engine/Misc/Tweening/Tweens.cs
@@ -271,6 +271,27 @@ namespace AGS.Engine
 		}
 
         /// <summary>
+        /// Tweens the brightness of the image (where 1 is default, 2 is twice as bright).
+        /// <example>
+        /// <code language="lang-csharp">
+        /// var tween = obj.TweenBrightness(2f, 2f, Ease.QuadOut);
+        /// await tween.Task;
+        /// </code>
+        /// </example>
+        /// <seealso cref="Tween"/>
+        /// <seealso cref="IHasImage.Brightness"/>
+        /// </summary>
+        /// <returns>The tween.</returns>
+        /// <param name="sprite">Sprite.</param>
+        /// <param name="toBrightness">To brightness.</param>
+        /// <param name="timeInSeconds">Time in seconds.</param>
+        /// <param name="easing">Easing function.</param>
+        public static Tween TweenBrightness(this IHasImage sprite, float toBrightness, float timeInSeconds, Func<float, float> easing = null)
+        {
+            return Tween.Run(sprite.Brightness.X, toBrightness, b => sprite.Brightness = new Vector4(b), timeInSeconds, easing);
+        }
+
+        /// <summary>
         /// Tweens the pivot point (its x position) of an image.
         /// <example>
         /// <code language="lang-csharp">

--- a/Source/Engine/AGS.Engine/Misc/Tweening/Tweens.cs
+++ b/Source/Engine/AGS.Engine/Misc/Tweening/Tweens.cs
@@ -202,7 +202,7 @@ namespace AGS.Engine
 		}
 
         /// <summary>
-        /// Tweens the hue of the image (based on HSLA color scheme).
+        /// Tweens the hue of the image's tint (based on HSLA color scheme).
         /// <example>
         /// <code language="lang-csharp">
         /// var tween = obj.TweenHue(0, 2f, Ease.QuadOut);
@@ -218,14 +218,14 @@ namespace AGS.Engine
         /// <param name="toHue">To hue.</param>
         /// <param name="timeInSeconds">Time in seconds.</param>
         /// <param name="easing">Easing function.</param>
-		public static Tween TweenHue(this IHasImage sprite, int toHue, float timeInSeconds, Func<float, float> easing = null)
+		public static Tween TweenTintHue(this IHasImage sprite, int toHue, float timeInSeconds, Func<float, float> easing = null)
 		{
 			return Tween.Run((float)sprite.Tint.GetHue(), (float)toHue, h => sprite.Tint = Color.FromHsla((int)h, sprite.Tint.GetSaturation(),
 				sprite.Tint.GetLightness(), sprite.Tint.A), timeInSeconds, easing);
 		}
 
         /// <summary>
-        /// Tweens the saturation of the image (based on HSLA color scheme).
+        /// Tweens the saturation of the image's tint (based on HSLA color scheme).
         /// <example>
         /// <code language="lang-csharp">
         /// var tween = obj.TweenSaturation(0f, 2f, Ease.QuadOut);
@@ -241,14 +241,14 @@ namespace AGS.Engine
         /// <param name="toSaturation">To saturation.</param>
         /// <param name="timeInSeconds">Time in seconds.</param>
         /// <param name="easing">Easing function.</param>
-		public static Tween TweenSaturation(this IHasImage sprite, float toSaturation, float timeInSeconds, Func<float, float> easing = null)
+		public static Tween TweenTintSaturation(this IHasImage sprite, float toSaturation, float timeInSeconds, Func<float, float> easing = null)
 		{
 			return Tween.Run(sprite.Tint.GetSaturation(), toSaturation, s => sprite.Tint = Color.FromHsla(sprite.Tint.GetHue(), s,
 				sprite.Tint.GetLightness(), sprite.Tint.A), timeInSeconds, easing);
 		}
 
         /// <summary>
-        /// Tweens the lightness of the image (based on HSLA color scheme).
+        /// Tweens the lightness of the image's tint (based on HSLA color scheme).
         /// <example>
         /// <code language="lang-csharp">
         /// var tween = obj.TweenLightness(0f, 2f, Ease.QuadOut);
@@ -264,7 +264,7 @@ namespace AGS.Engine
         /// <param name="toLightness">To lightness.</param>
         /// <param name="timeInSeconds">Time in seconds.</param>
         /// <param name="easing">Easing function.</param>
-		public static Tween TweenLightness(this IHasImage sprite, float toLightness, float timeInSeconds, Func<float, float> easing = null)
+		public static Tween TweenTintLightness(this IHasImage sprite, float toLightness, float timeInSeconds, Func<float, float> easing = null)
 		{
 			return Tween.Run(sprite.Tint.GetLightness(), toLightness, l => sprite.Tint = Color.FromHsla(sprite.Tint.GetHue(), 
 				sprite.Tint.GetSaturation(), l, sprite.Tint.A), timeInSeconds, easing);
@@ -289,6 +289,27 @@ namespace AGS.Engine
         public static Tween TweenBrightness(this IHasImage sprite, float toBrightness, float timeInSeconds, Func<float, float> easing = null)
         {
             return Tween.Run(sprite.Brightness.X, toBrightness, b => sprite.Brightness = new Vector4(b), timeInSeconds, easing);
+        }
+
+        /// <summary>
+        /// Tweens the saturation of the image (where 1 is default, 0 is completely unsaturated).
+        /// <example>
+        /// <code language="lang-csharp">
+        /// var tween = obj.TweenSaturation(0f, 2f, Ease.QuadOut);
+        /// await tween.Task;
+        /// </code>
+        /// </example>
+        /// <seealso cref="Tween"/>
+        /// <seealso cref="ISaturationEffectComponent.Saturation"/>
+        /// </summary>
+        /// <returns>The saturation.</returns>
+        /// <param name="effect">Effect.</param>
+        /// <param name="toSaturation">To saturation.</param>
+        /// <param name="timeInSeconds">Time in seconds.</param>
+        /// <param name="easing">Easing function.</param>
+        public static Tween TweenSaturation(this ISaturationEffectComponent effect, float toSaturation, float timeInSeconds, Func<float, float> easing = null)
+        {
+            return Tween.Run(effect.Saturation, toSaturation, s => effect.Saturation = s, timeInSeconds, easing);
         }
 
         /// <summary>

--- a/Source/Engine/AGS.Engine/UI/DebugControls/DebugView/Inspector/AGSInspector.cs
+++ b/Source/Engine/AGS.Engine/UI/DebugControls/DebugView/Inspector/AGSInspector.cs
@@ -210,6 +210,8 @@ namespace AGS.Engine
             else if (propType == typeof(PointF)) editor = new PointFPropertyEditor(_state, _factory, false);
             else if (propType == typeof(Point)) editor = new PointPropertyEditor(_state, _factory, false);
             else if (propType == typeof(Vector2)) editor = new Vector2PropertyEditor(_state, _factory, false);
+            else if (propType == typeof(Vector3)) editor = new Vector3PropertyEditor(_state, _factory, false);
+            else if (propType == typeof(Vector4)) editor = new Vector4PropertyEditor(_state, _factory, false);
             else if (propType == typeof(ILocation))
             {
                 var entity = _currentEntity;
@@ -226,6 +228,8 @@ namespace AGS.Engine
             else if (propType == typeof(PointF?)) editor = new PointFPropertyEditor(_state, _factory, true);
             else if (propType == typeof(Point?)) editor = new PointPropertyEditor(_state, _factory, true);
             else if (propType == typeof(Vector2?)) editor = new Vector2PropertyEditor(_state, _factory, true);
+            else if (propType == typeof(Vector3?)) editor = new Vector3PropertyEditor(_state, _factory, true);
+            else if (propType == typeof(Vector4?)) editor = new Vector4PropertyEditor(_state, _factory, true);
             else if (propType == typeof(RectangleF?)) editor = new RectangleFPropertyEditor(_state, _factory, true);
             else if (propType == typeof(Rectangle?)) editor = new RectanglePropertyEditor(_state, _factory, true);
 

--- a/Source/Engine/AGS.Engine/UI/DebugControls/DebugView/Inspector/Editors/ColorPropertyEditor.cs
+++ b/Source/Engine/AGS.Engine/UI/DebugControls/DebugView/Inspector/Editors/ColorPropertyEditor.cs
@@ -45,6 +45,8 @@ namespace AGS.Engine
             _colorLabel = _factory.UI.GetLabel($"{id}_ColorLabel", "", 50f, 25f, combobox.Width + 10f, 0f, label.TreeNode.Parent);
             _colorLabel.TextVisible = false;
 
+            view.HorizontalPanel.GetComponent<ITreeTableRowLayoutComponent>().RestrictionList.RestrictionList.AddRange(new List<string> { combobox.ID, _colorLabel.ID });
+
             RefreshUI();
             _text.TextConfig.AutoFit = AutoFit.TextShouldFitLabel;
             _text.TextConfig.Alignment = Alignment.MiddleLeft;

--- a/Source/Engine/AGS.Engine/UI/DebugControls/DebugView/Inspector/Editors/NumberPropertyEditor.cs
+++ b/Source/Engine/AGS.Engine/UI/DebugControls/DebugView/Inspector/Editors/NumberPropertyEditor.cs
@@ -35,6 +35,7 @@ namespace AGS.Engine
                     {
                         editor.SuggestedMinValue = slider.SliderMin;
                         editor.SuggestedMaxValue = slider.SliderMax;
+                        editor.Step = slider.Step;
                     }
                     else configureNumberEditor?.Invoke(this, editor);
                 };

--- a/Source/Engine/AGS.Engine/UI/DebugControls/DebugView/Inspector/Editors/NumberPropertyEditor.cs
+++ b/Source/Engine/AGS.Engine/UI/DebugControls/DebugView/Inspector/Editors/NumberPropertyEditor.cs
@@ -254,7 +254,7 @@ namespace AGS.Engine
                                              params (string text, Func<float, T, T> getValue)[] creators) :
         base(state, factory, wholeNumbers, nullable, creators.Select((creator, index) =>
             new InternalNumberEditor(creator.text, prop => prop.Value == InspectorProperty.NullValue ?
-                                     InspectorProperty.NullValue : prop.Value.Split(',')[index],
+                                     InspectorProperty.NullValue : prop.Value.Replace("(", "").Replace(")", "").Split(',')[index],
                                      (prop, value) =>
             {
                 object objVal = prop.Prop.GetValue(prop.Object);
@@ -299,6 +299,25 @@ namespace AGS.Engine
         public Vector2PropertyEditor(IGameState state, IGameFactory factory, bool nullable) : base(state, factory, false, nullable, null,
                            ("X", (x, vector) => new Vector2(x, vector.Y)),
                            ("Y", (y, vector) => new Vector2(vector.X, y)))
+        { }
+    }
+
+    public class Vector3PropertyEditor : MultipleNumbersPropertyEditor<Vector3>
+    {
+        public Vector3PropertyEditor(IGameState state, IGameFactory factory, bool nullable) : base(state, factory, false, nullable, null,
+                           ("X", (x, vector) => new Vector3(x, vector.Y, vector.Z)),
+                           ("Y", (y, vector) => new Vector3(vector.X, y, vector.Z)),
+                           ("Z", (z, vector) => new Vector3(vector.X, vector.Y, z)))
+        { }
+    }
+
+    public class Vector4PropertyEditor : MultipleNumbersPropertyEditor<Vector4>
+    {
+        public Vector4PropertyEditor(IGameState state, IGameFactory factory, bool nullable) : base(state, factory, false, nullable, null,
+                           ("X", (x, vector) => new Vector4(x, vector.Y, vector.Z, vector.W)),
+                           ("Y", (y, vector) => new Vector4(vector.X, y, vector.Z, vector.W)),
+                           ("Z", (z, vector) => new Vector4(vector.X, vector.Y, z, vector.W)),
+                           ("W", (w, vector) => new Vector4(vector.X, vector.Y, vector.Z, w)))
         { }
     }
 

--- a/Source/Engine/AGS.Engine/UI/DebugControls/DebugView/Inspector/Editors/StringPropertyEditor.cs
+++ b/Source/Engine/AGS.Engine/UI/DebugControls/DebugView/Inspector/Editors/StringPropertyEditor.cs
@@ -21,6 +21,7 @@ namespace AGS.Engine
             _property = property;
 			var label = view.TreeItem;
             var config = _enabled ? GameViewColors.TextConfig : GameViewColors.ReadonlyTextConfig;
+            if (!_enabled) view.HorizontalPanel.GetComponent<ITreeTableRowLayoutComponent>().RestrictionList.RestrictionList.Add(id);
 			var textbox = _factory.UI.GetTextBox(id,
 												 label.X, label.Y, label.TreeNode.Parent,
 												 "", config, width: 100f, height: 20f);

--- a/Source/Tests/Engine/Misc/Tweens/TweensTests.cs
+++ b/Source/Tests/Engine/Misc/Tweens/TweensTests.cs
@@ -38,10 +38,10 @@ namespace Tests
             AGSSprite sprite = new AGSSprite (resolver, null);
 			sprite.Tint = Color.FromHsla(0, 1f, 0.75f, 100); //Lightness must be different than 1 for hue to change
 
-			await sprite.TweenHue(359, 1f).Task;
+			await sprite.TweenTintHue(359, 1f).Task;
 			Assert.AreEqual(359, sprite.Tint.GetHue());
 
-			await sprite.TweenHue(0, 1f, Ease.QuadIn).Task;
+			await sprite.TweenTintHue(0, 1f, Ease.QuadIn).Task;
 			Assert.AreEqual(0, sprite.Tint.GetHue());
 		}
 
@@ -53,10 +53,10 @@ namespace Tests
             AGSSprite sprite = new AGSSprite (resolver, null);
 			sprite.Tint = Color.FromHsla(100, 1f, 0.5f, 100); //Lightness must be different than 1 for saturation to change
 
-			await sprite.TweenSaturation(0f, 1f, Ease.QuadIn).Task;
+			await sprite.TweenTintSaturation(0f, 1f, Ease.QuadIn).Task;
 			Assert.IsTrue(Math.Abs(sprite.Tint.GetSaturation()) < 0.0001f);
 
-			await sprite.TweenSaturation(1f, 1f).Task;
+			await sprite.TweenTintSaturation(1f, 1f).Task;
 			Assert.IsTrue(Math.Abs(1f - sprite.Tint.GetSaturation()) < 0.0001f);
 		}
 


### PR DESCRIPTION
Added brightness and saturation modifiers.

Brightness: allows to change brightness for each of the RGBA components separately. This is applied on top of the color tint, and allows to make the image brighter than it was originally.

Saturation: this comes as a separate component (as it uses a custom shader) and allows to modify the saturation of an image. It can either be applied to a specific entity or to the entire screen.

A demo where we adjust the brightness & saturation to our character from the inspector:
![Demo](https://media.giphy.com/media/w8pZV3DOA5021LumMt/giphy.gif)

Also added demos in the tweens panel.

Resolves #266 