### PR TITLE
Fix matching areas didn't use world position

### DIFF
--- a/Source/AGS.API/AGS.API.csproj
+++ b/Source/AGS.API/AGS.API.csproj
@@ -278,6 +278,7 @@
     <Compile Include="Game\IRepeatedlyExecuteEventArgs.cs" />
     <Compile Include="Misc\Events\ClaimEventToken.cs" />
     <Compile Include="Graphics\Effects\ISaturationEffectComponent.cs" />
+    <Compile Include="Objects\IWorldPositionComponent.cs" />
   </ItemGroup>
   <Import Project="$(MSBuildExtensionsPath32)\Microsoft\Portable\$(TargetFrameworkVersion)\Microsoft.Portable.CSharp.targets" />
   <ItemGroup />

--- a/Source/AGS.API/Audio/ISoundEmitter.cs
+++ b/Source/AGS.API/Audio/ISoundEmitter.cs
@@ -32,11 +32,11 @@
         IObject Object { set; }
 
         /// <summary>
-        /// Gets or sets the translate component (for binding to location).
+        /// Gets or sets the world position component (for binding to location).
         /// You can set the Object property instead a short-hand convience. 
         /// </summary>
         /// <value>The translate.</value>
-        ITranslate Translate { get; set; }
+        IWorldPositionComponent WorldPosition { get; set; }
 
         /// <summary>
         /// Gets or sets the room component, for the emitter to not play the sound if the entity is not in currently rendered room.

--- a/Source/AGS.API/Graphics/Logic/DisplayList/IDisplayList.cs
+++ b/Source/AGS.API/Graphics/Logic/DisplayList/IDisplayList.cs
@@ -13,5 +13,10 @@ namespace AGS.API
 		/// <returns>The display list.</returns>
 		/// <param name="viewport">Viewport.</param>
 		List<IObject> GetDisplayList(IViewport viewport);
+
+        /// <summary>
+        /// Update the display list (this is called every tick by the game engine itself).
+        /// </summary>
+        void Update();
     }
 }

--- a/Source/AGS.API/Input/MousePosition.cs
+++ b/Source/AGS.API/Input/MousePosition.cs
@@ -124,11 +124,11 @@ namespace AGS.API
             x = xyz.X;
             y = xyz.Y;
 
-			var boundingBoxes = projectedInto.TreeNode.Parent?.GetBoundingBoxes(viewport);
-            if (boundingBoxes != null && boundingBoxes.RenderBox.IsValid)
+            var hitTestBox = projectedInto.TreeNode.Parent?.HitTestBoundingBox;
+            if (hitTestBox?.IsValid ?? false)
 			{
-				x -= boundingBoxes.HitTestBox.MinX;
-				y -= boundingBoxes.HitTestBox.MinY;
+                x -= hitTestBox.Value.MinX;
+                y -= hitTestBox.Value.MinY;
 			}
             var renderLayer = projectedInto.RenderLayer;
 			if (renderLayer?.IndependentResolution != null)

--- a/Source/AGS.API/Input/MousePosition.cs
+++ b/Source/AGS.API/Input/MousePosition.cs
@@ -62,8 +62,8 @@ namespace AGS.API
             var parentBoundingBoxes = viewport.Parent?.GetBoundingBoxes(_mainViewport);
             if (parentBoundingBoxes != null)
             {
-                projectLeft += parentBoundingBoxes.RenderBox.MinX;
-                projectRight += parentBoundingBoxes.RenderBox.MinX;
+                projectLeft += parentBoundingBoxes.ViewportBox.MinX;
+                projectRight += parentBoundingBoxes.ViewportBox.MinX;
             }
 
             float x = MathUtils.Lerp(projectLeft, 0f, projectRight, VirtualResolution.Width, XWindow);
@@ -83,8 +83,8 @@ namespace AGS.API
             var parentBoundingBoxes = viewport.Parent?.GetBoundingBoxes(_mainViewport);
             if (parentBoundingBoxes != null)
             {
-                projectBottom -= parentBoundingBoxes.RenderBox.MinY;
-                projectTop -= parentBoundingBoxes.RenderBox.MinY;
+                projectBottom -= parentBoundingBoxes.ViewportBox.MinY;
+                projectTop -= parentBoundingBoxes.ViewportBox.MinY;
             }
 
             float y = MathUtils.Lerp(projectBottom, 0f, projectTop, VirtualResolution.Height, YWindow);
@@ -109,10 +109,10 @@ namespace AGS.API
             var parentBoundingBoxes = viewport.Parent?.GetBoundingBoxes(_mainViewport);
             if (parentBoundingBoxes != null)
             {
-                projectLeft += parentBoundingBoxes.RenderBox.MinX;
-                projectRight += parentBoundingBoxes.RenderBox.MinX;
-                projectBottom -= parentBoundingBoxes.RenderBox.MinY;
-                projectTop -= parentBoundingBoxes.RenderBox.MinY;
+                projectLeft += parentBoundingBoxes.ViewportBox.MinX;
+                projectRight += parentBoundingBoxes.ViewportBox.MinX;
+                projectBottom -= parentBoundingBoxes.ViewportBox.MinY;
+                projectTop -= parentBoundingBoxes.ViewportBox.MinY;
             }
             float y = MathUtils.Lerp(projectTop, VirtualResolution.Height, projectBottom, 0f, YWindow);
             float x = MathUtils.Lerp(projectLeft, 0f, projectRight, VirtualResolution.Width, XWindow);
@@ -124,7 +124,7 @@ namespace AGS.API
             x = xyz.X;
             y = xyz.Y;
 
-            var hitTestBox = projectedInto.TreeNode.Parent?.HitTestBoundingBox;
+            var hitTestBox = projectedInto.TreeNode.Parent?.WorldBoundingBox;
             if (hitTestBox?.IsValid ?? false)
 			{
                 x -= hitTestBox.Value.MinX;

--- a/Source/AGS.API/Misc/Geometry/AGSBoundingBoxes.cs
+++ b/Source/AGS.API/Misc/Geometry/AGSBoundingBoxes.cs
@@ -10,18 +10,18 @@
         #region AGSBoundingBoxes implementation
 
         /// <summary>
-        /// Gets or sets the render box used for rendering the entity.
+        /// Gets or sets the bounding box in viewport coordinages (used for rendering the entity).
         /// This should be only set from the engine.
         /// </summary>
         /// <value>The render box.</value>
-        public AGSBoundingBox RenderBox { get; set; }
+        public AGSBoundingBox ViewportBox { get; set; }
 
         /// <summary>
-        /// Gets or sets the hit-test box used for collision checks.
+        /// Gets or sets the bounding box in world coordinates (used for collision checks).
         /// This should be only set from the engine.
         /// </summary>
         /// <value>The hit-test box.</value>
-        public AGSBoundingBox HitTestBox { get; set; }
+        public AGSBoundingBox WorldBox { get; set; }
 
         /// <summary>
         /// Gets or sets the texture box which specifies which part of the texture is used on the render box.
@@ -32,12 +32,12 @@
         public FourCorners<Vector2> TextureBox { get; set; }
 
         /// <summary>
-        /// Gets or sets the render box before the object was cropped.
-        /// This will usually be the same as the render box unless the object was actually cropped (i.e if
+        /// Gets or sets the viewport bounding box before the object was cropped.
+        /// This will usually be the same as the viewport box unless the object was actually cropped (i.e if
         /// it had the <see cref="ICropSelfComponent"/> attached, maybe inside a scrolling panel, for example).
         /// </summary>
         /// <value>The pre crop render box.</value>
-        public AGSBoundingBox PreCropRenderBox { get; set; }
+        public AGSBoundingBox PreCropViewportBox { get; set; }
 
         #endregion
 
@@ -48,15 +48,15 @@
             if (TextureBox == null && boxes.TextureBox != null) return false;
             if (TextureBox != null && boxes.TextureBox == null) return false;
             if (TextureBox != null && !TextureBox.Equals(boxes.TextureBox)) return false;
-            return RenderBox.Equals(boxes.RenderBox) && HitTestBox.Equals(boxes.HitTestBox)
-                            && PreCropRenderBox.Equals(boxes.PreCropRenderBox);
+            return ViewportBox.Equals(boxes.ViewportBox) && WorldBox.Equals(boxes.WorldBox)
+                            && PreCropViewportBox.Equals(boxes.PreCropViewportBox);
         }
 
         public void CopyFrom(AGSBoundingBoxes boxes)
         {
-            RenderBox = boxes.RenderBox;
-            HitTestBox = boxes.HitTestBox;
-            PreCropRenderBox = boxes.PreCropRenderBox;
+            ViewportBox = boxes.ViewportBox;
+            WorldBox = boxes.WorldBox;
+            PreCropViewportBox = boxes.PreCropViewportBox;
             TextureBox = boxes.TextureBox;
         }
 	}

--- a/Source/AGS.API/Objects/Collisions/IBoundingBoxComponent.cs
+++ b/Source/AGS.API/Objects/Collisions/IBoundingBoxComponent.cs
@@ -12,11 +12,16 @@
     public interface IBoundingBoxComponent : IComponent
     {
         /// <summary>
-        /// Gets or sets the bounding box which surrounds the entity.
-        /// The bounding box is set by the engine, and should not be set by the user.
+        /// Gets the bounding boxes which surrounds the entity.
         /// </summary>
         /// <value>The bounding boxes.</value>
         AGSBoundingBoxes GetBoundingBoxes(IViewport viewport);
+
+        /// <summary>
+        /// Gets the hit test bounding box (the entity's bounding box in world co-ordinates).
+        /// </summary>
+        /// <value>The hit test bounding box.</value>
+        AGSBoundingBox HitTestBoundingBox { get; }
 
         /// <summary>
         /// An event which fires whenever the bounding boxes for the entity change.

--- a/Source/AGS.API/Objects/Collisions/IBoundingBoxComponent.cs
+++ b/Source/AGS.API/Objects/Collisions/IBoundingBoxComponent.cs
@@ -18,10 +18,10 @@
         AGSBoundingBoxes GetBoundingBoxes(IViewport viewport);
 
         /// <summary>
-        /// Gets the hit test bounding box (the entity's bounding box in world co-ordinates).
+        /// Gets the entity's bounding box in world co-ordinates (can be used for hit-tests).
         /// </summary>
-        /// <value>The hit test bounding box.</value>
-        AGSBoundingBox HitTestBoundingBox { get; }
+        /// <value>The world bounding box.</value>
+        AGSBoundingBox WorldBoundingBox { get; }
 
         /// <summary>
         /// An event which fires whenever the bounding boxes for the entity change.

--- a/Source/AGS.API/Objects/IModelMatrixComponent.cs
+++ b/Source/AGS.API/Objects/IModelMatrixComponent.cs
@@ -26,6 +26,7 @@
     [RequiredComponent(typeof(IHasRoomComponent))]
     [RequiredComponent(typeof(IDrawableInfoComponent))]
     [RequiredComponent(typeof(IInObjectTreeComponent))]
+    [RequiredComponent(typeof(IWorldPositionComponent))]
     public interface IModelMatrixComponent : IComponent
     {
         /// <summary>

--- a/Source/AGS.API/Objects/IObject.cs
+++ b/Source/AGS.API/Objects/IObject.cs
@@ -7,7 +7,7 @@
 	public interface IObject : IEntity, IHasRoomComponent, IAnimationComponent, IInObjectTreeComponent, IColliderComponent, 
 		IVisibleComponent, IEnabledComponent, ICustomPropertiesComponent, IDrawableInfoComponent, 
         IShaderComponent, ITranslateComponent, IImageComponent, IScaleComponent, IRotateComponent, 
-        IPixelPerfectComponent, IHasModelMatrix, IModelMatrixComponent, IBoundingBoxComponent
+        IPixelPerfectComponent, IHasModelMatrix, IModelMatrixComponent, IBoundingBoxComponent, IWorldPositionComponent
 	{
 	}
 }

--- a/Source/AGS.API/Objects/ITranslateComponent.cs
+++ b/Source/AGS.API/Objects/ITranslateComponent.cs
@@ -9,24 +9,34 @@ namespace AGS.API
     {
         /// <summary>
         /// Gets or sets the location.
-        /// (X,Y) are used to place the entity/sprite in 2D space (in room coordinates).
+        /// (X,Y) are used to place the entity/sprite in 2D space (in local coordinates).
+        /// The local coordinates are the world coordinates if the entity has no parent, otherwise its 
+        /// the coordinates relative to the parent.
+        /// 
         /// Z is used for deciding how the entities/sprites are ordered in 2D space (higher Z in front).
         /// If Z and Y are the same when setting the location, then Z will be bound to Y: whenever Y moves,
         /// Z moves, which will make entities closer to the bottom appear in front, which is the desired behavior
         /// in most scenarios. You can change this behavior by explicitly setting Z to a different value.
         /// </summary>
+        /// <seealso cref="IWorldPositionComponent"/>
         /// <value>The location.</value>
         ILocation Location { get; set; }
 
         /// <summary>
-        /// Gets or sets the x coordinate (in room coordinates).
+        /// Gets or sets the x coordinate (in local coordinates).
+        /// The local coordinates are the world coordinates if the entity has no parent, otherwise its 
+        /// the coordinates relative to the parent.
         /// </summary>
+        /// <seealso cref="IWorldPositionComponent.WorldX"/>
         /// <value>The x.</value>
         float X { get; set; }
 
         /// <summary>
-        /// Gets or sets the y coordinate (in room coordinates).
+        /// Gets or sets the y coordinate (in local coordinates).
+        /// The local coordinates are the world coordinates if the entity has no parent, otherwise its 
+        /// the coordinates relative to the parent.
         /// </summary>
+        /// <seealso cref="IWorldPositionComponent.WorldY"/>
         /// <value>The y.</value>
         float Y { get; set; }
 

--- a/Source/AGS.API/Objects/IWorldPositionComponent.cs
+++ b/Source/AGS.API/Objects/IWorldPositionComponent.cs
@@ -21,5 +21,13 @@ namespace AGS.API
         /// </summary>
         /// <value>The world y.</value>
         float WorldY { get; }
+
+        /// <summary>
+        /// Get the (X,Y) of an entity in world coordinates.
+        /// In case the entity has no parents, the value will be the same as <see cref="ITranslate.Location"/>,
+        /// but if the entity has a parent, then WorldXY will give you the absolute world value (as opposed to relative to the parent).
+        /// </summary>
+        /// <value>The world y.</value>
+        PointF WorldXY { get; }
     }
 }

--- a/Source/AGS.API/Objects/IWorldPositionComponent.cs
+++ b/Source/AGS.API/Objects/IWorldPositionComponent.cs
@@ -1,0 +1,25 @@
+﻿using System;
+namespace AGS.API
+{
+    /// <summary>
+    /// Allows getting the world position for entities.
+    /// </summary>
+    public interface IWorldPositionComponent : IComponent
+    {
+        /// <summary>
+        /// Get the X of an entity in world coordinates.
+        /// In case the entity has no parents, the value will be the same as <see cref="ITranslate.X"/>,
+        /// but if the entity has a parent, then WorldX will give you the absolute world value (as opposed to relative to the parent).
+        /// </summary>
+        /// <value>The world x.</value>
+        float WorldX { get; }
+
+        /// <summary>
+        /// Get the Y of an entity in world coordinates.
+        /// In case the entity has no parents, the value will be the same as <see cref="ITranslate.Y"/>,
+        /// but if the entity has a parent, then WorldY will give you the absolute world value (as opposed to relative to the parent).
+        /// </summary>
+        /// <value>The world y.</value>
+        float WorldY { get; }
+    }
+}

--- a/Source/Engine/AGS.Engine/AGS.Engine.csproj
+++ b/Source/Engine/AGS.Engine/AGS.Engine.csproj
@@ -33,4 +33,101 @@
       <HintPath>..\..\..\DLLs\protobuf-net.dll</HintPath>
     </Reference>
   </ItemGroup>
+  <ItemGroup>
+    <None Update="ComponentsFramework\Templates\AGSButton.tt">
+      <Generator>TextTemplatingFileGenerator</Generator>
+      <LastGenOutput>AGSButton.generated.cs</LastGenOutput>
+    </None>
+    <None Update="ComponentsFramework\Templates\AGSCharacter.tt">
+      <Generator>TextTemplatingFileGenerator</Generator>
+      <LastGenOutput>AGSCharacter.generated.cs</LastGenOutput>
+    </None>
+    <None Update="ComponentsFramework\Templates\AGSCheckbox.tt">
+      <Generator>TextTemplatingFileGenerator</Generator>
+      <LastGenOutput>AGSCheckbox.generated.cs</LastGenOutput>
+    </None>
+    <None Update="ComponentsFramework\Templates\AGSComboBox.tt">
+      <Generator>TextTemplatingFileGenerator</Generator>
+      <LastGenOutput>AGSComboBox.generated.cs</LastGenOutput>
+    </None>
+    <None Update="ComponentsFramework\Templates\AGSInventoryWindow.tt">
+      <Generator>TextTemplatingFileGenerator</Generator>
+      <LastGenOutput>AGSInventoryWindow.generated.cs</LastGenOutput>
+    </None>
+    <None Update="ComponentsFramework\Templates\AGSLabel.tt">
+      <Generator>TextTemplatingFileGenerator</Generator>
+      <LastGenOutput>AGSLabel.generated.cs</LastGenOutput>
+    </None>
+    <None Update="ComponentsFramework\Templates\AGSObject.tt">
+      <Generator>TextTemplatingFileGenerator</Generator>
+      <LastGenOutput>AGSObject.generated.cs</LastGenOutput>
+    </None>
+    <None Update="ComponentsFramework\Templates\AGSPanel.tt">
+      <Generator>TextTemplatingFileGenerator</Generator>
+      <LastGenOutput>AGSPanel.generated.cs</LastGenOutput>
+    </None>
+    <None Update="ComponentsFramework\Templates\AGSSlider.tt">
+      <Generator>TextTemplatingFileGenerator</Generator>
+      <LastGenOutput>AGSSlider.generated.cs</LastGenOutput>
+    </None>
+    <None Update="ComponentsFramework\Templates\AGSTextbox.tt">
+      <Generator>TextTemplatingFileGenerator</Generator>
+      <LastGenOutput>AGSTextbox.generated.cs</LastGenOutput>
+    </None>
+  </ItemGroup>
+  <ItemGroup>
+    <Service Include="{508349b6-6b84-4df5-91f0-309beebad82d}" />
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Update="ComponentsFramework\Templates\AGSButton.generated.cs">
+      <DesignTime>True</DesignTime>
+      <AutoGen>True</AutoGen>
+      <DependentUpon>AGSButton.tt</DependentUpon>
+    </Compile>
+    <Compile Update="ComponentsFramework\Templates\AGSCharacter.generated.cs">
+      <DesignTime>True</DesignTime>
+      <AutoGen>True</AutoGen>
+      <DependentUpon>AGSCharacter.tt</DependentUpon>
+    </Compile>
+    <Compile Update="ComponentsFramework\Templates\AGSCheckbox.generated.cs">
+      <DesignTime>True</DesignTime>
+      <AutoGen>True</AutoGen>
+      <DependentUpon>AGSCheckbox.tt</DependentUpon>
+    </Compile>
+    <Compile Update="ComponentsFramework\Templates\AGSComboBox.generated.cs">
+      <DesignTime>True</DesignTime>
+      <AutoGen>True</AutoGen>
+      <DependentUpon>AGSComboBox.tt</DependentUpon>
+    </Compile>
+    <Compile Update="ComponentsFramework\Templates\AGSInventoryWindow.generated.cs">
+      <DesignTime>True</DesignTime>
+      <AutoGen>True</AutoGen>
+      <DependentUpon>AGSInventoryWindow.tt</DependentUpon>
+    </Compile>
+    <Compile Update="ComponentsFramework\Templates\AGSLabel.generated.cs">
+      <DesignTime>True</DesignTime>
+      <AutoGen>True</AutoGen>
+      <DependentUpon>AGSLabel.tt</DependentUpon>
+    </Compile>
+    <Compile Update="ComponentsFramework\Templates\AGSObject.generated.cs">
+      <DesignTime>True</DesignTime>
+      <AutoGen>True</AutoGen>
+      <DependentUpon>AGSObject.tt</DependentUpon>
+    </Compile>
+    <Compile Update="ComponentsFramework\Templates\AGSPanel.generated.cs">
+      <DesignTime>True</DesignTime>
+      <AutoGen>True</AutoGen>
+      <DependentUpon>AGSPanel.tt</DependentUpon>
+    </Compile>
+    <Compile Update="ComponentsFramework\Templates\AGSSlider.generated.cs">
+      <DesignTime>True</DesignTime>
+      <AutoGen>True</AutoGen>
+      <DependentUpon>AGSSlider.tt</DependentUpon>
+    </Compile>
+    <Compile Update="ComponentsFramework\Templates\AGSTextbox.generated.cs">
+      <DesignTime>True</DesignTime>
+      <AutoGen>True</AutoGen>
+      <DependentUpon>AGSTextbox.tt</DependentUpon>
+    </Compile>
+  </ItemGroup>
 </Project>

--- a/Source/Engine/AGS.Engine/Audio/AGSSoundEmitter.cs
+++ b/Source/Engine/AGS.Engine/Audio/AGSSoundEmitter.cs
@@ -62,11 +62,11 @@ namespace AGS.Engine
 
         public IObject Object 
         { 
-            set { Translate = value; HasRoom = value; EntityID = value == null ? null : value.ID; }
+            set { HasRoom = value; WorldPosition = value; EntityID = value == null ? null : value.ID; }
         }
         public string EntityID { get; set; }
-        public ITranslate Translate { get; set; }
         public IHasRoomComponent HasRoom { get; set; }
+        public IWorldPositionComponent WorldPosition { get; set; }
 
 		public bool AutoPan { get; set; }
 		public bool AutoAdjustVolume { get; set; }
@@ -109,7 +109,7 @@ namespace AGS.Engine
 		private void onRepeatedlyExecute()
 		{
 			if (_game.State.Paused) return;
-            var obj = Translate;
+            var pos = WorldPosition;
             var hasRoom = HasRoom;
 
 			foreach (var sound in _playingSounds)
@@ -120,10 +120,10 @@ namespace AGS.Engine
 					_playingSounds.TryRemove(sound.Key, out value);
 					continue;
 				}
-				if (obj == null) continue;
+				if (pos == null) continue;
 				if (AutoPan)
 				{
-					float pan = MathUtils.Lerp(0f, -1f, _game.Settings.VirtualResolution.Width, 1f, obj.Location.X);
+                    float pan = MathUtils.Lerp(0f, -1f, _game.Settings.VirtualResolution.Width, 1f, pos.WorldX);
 					sound.Value.Sound.Panning = pan;
 				}
 				if (AutoAdjustVolume)
@@ -131,11 +131,11 @@ namespace AGS.Engine
                     if (hasRoom == null) continue;
                     var room = _game.State.Room;
                     if (room != hasRoom.Room) return;
-                    foreach (var area in room.GetMatchingAreas(obj.Location.XY, EntityID))
+                    foreach (var area in room.GetMatchingAreas(pos.WorldXY, EntityID))
 					{
                         var scalingArea = area.GetComponent<IScalingArea>();
                         if (scalingArea == null || !scalingArea.ScaleVolume) continue;
-						float scale = scalingArea.GetScaling(obj.Y);
+                        float scale = scalingArea.GetScaling(pos.WorldY);
 						sound.Value.Sound.Volume = AudioClip.Volume * scale;
 					}
 				}

--- a/Source/Engine/AGS.Engine/ComponentsFramework/Templates/AGSButton.generated.cs
+++ b/Source/Engine/AGS.Engine/ComponentsFramework/Templates/AGSButton.generated.cs
@@ -576,6 +576,11 @@ namespace AGS.Engine
             get { return _worldPositionComponent.WorldY; } 
         }
 
+        public PointF WorldXY
+        {
+            get { return _worldPositionComponent.WorldXY; }
+        }
+
         #endregion
 
         #region ITextComponent implementation

--- a/Source/Engine/AGS.Engine/ComponentsFramework/Templates/AGSButton.generated.cs
+++ b/Source/Engine/AGS.Engine/ComponentsFramework/Templates/AGSButton.generated.cs
@@ -32,49 +32,52 @@ namespace AGS.Engine
         private IPixelPerfectComponent _pixelPerfectComponent;
         private IModelMatrixComponent _modelMatrixComponent;
         private IBoundingBoxComponent _boundingBoxComponent;
+        private IWorldPositionComponent _worldPositionComponent;
         private ITextComponent _textComponent;
         private IButtonComponent _buttonComponent;
 
         public AGSButton(string id, Resolver resolver) : base(id, resolver)
-        {            
+        {
             _uIEvents = AddComponent<IUIEvents>();
-            Bind<IUIEvents>(c => _uIEvents = c, _ => {});            
+            Bind<IUIEvents>(c => _uIEvents = c, _ => {});
             _skinComponent = AddComponent<ISkinComponent>();
-            Bind<ISkinComponent>(c => _skinComponent = c, _ => {});            
+            Bind<ISkinComponent>(c => _skinComponent = c, _ => {});
             _hasRoomComponent = AddComponent<IHasRoomComponent>();
-            Bind<IHasRoomComponent>(c => _hasRoomComponent = c, _ => {});            
+            Bind<IHasRoomComponent>(c => _hasRoomComponent = c, _ => {});
             _animationComponent = AddComponent<IAnimationComponent>();
-            Bind<IAnimationComponent>(c => _animationComponent = c, _ => {});            
+            Bind<IAnimationComponent>(c => _animationComponent = c, _ => {});
             _inObjectTreeComponent = AddComponent<IInObjectTreeComponent>();
-            Bind<IInObjectTreeComponent>(c => _inObjectTreeComponent = c, _ => {});            
+            Bind<IInObjectTreeComponent>(c => _inObjectTreeComponent = c, _ => {});
             _colliderComponent = AddComponent<IColliderComponent>();
-            Bind<IColliderComponent>(c => _colliderComponent = c, _ => {});            
+            Bind<IColliderComponent>(c => _colliderComponent = c, _ => {});
             _visibleComponent = AddComponent<IVisibleComponent>();
-            Bind<IVisibleComponent>(c => _visibleComponent = c, _ => {});            
+            Bind<IVisibleComponent>(c => _visibleComponent = c, _ => {});
             _enabledComponent = AddComponent<IEnabledComponent>();
-            Bind<IEnabledComponent>(c => _enabledComponent = c, _ => {});            
+            Bind<IEnabledComponent>(c => _enabledComponent = c, _ => {});
             _customPropertiesComponent = AddComponent<ICustomPropertiesComponent>();
-            Bind<ICustomPropertiesComponent>(c => _customPropertiesComponent = c, _ => {});            
+            Bind<ICustomPropertiesComponent>(c => _customPropertiesComponent = c, _ => {});
             _drawableInfoComponent = AddComponent<IDrawableInfoComponent>();
-            Bind<IDrawableInfoComponent>(c => _drawableInfoComponent = c, _ => {});            
+            Bind<IDrawableInfoComponent>(c => _drawableInfoComponent = c, _ => {});
             _shaderComponent = AddComponent<IShaderComponent>();
-            Bind<IShaderComponent>(c => _shaderComponent = c, _ => {});            
+            Bind<IShaderComponent>(c => _shaderComponent = c, _ => {});
             _translateComponent = AddComponent<ITranslateComponent>();
-            Bind<ITranslateComponent>(c => _translateComponent = c, _ => {});            
+            Bind<ITranslateComponent>(c => _translateComponent = c, _ => {});
             _imageComponent = AddComponent<IImageComponent>();
-            Bind<IImageComponent>(c => _imageComponent = c, _ => {});            
+            Bind<IImageComponent>(c => _imageComponent = c, _ => {});
             _scaleComponent = AddComponent<IScaleComponent>();
-            Bind<IScaleComponent>(c => _scaleComponent = c, _ => {});            
+            Bind<IScaleComponent>(c => _scaleComponent = c, _ => {});
             _rotateComponent = AddComponent<IRotateComponent>();
-            Bind<IRotateComponent>(c => _rotateComponent = c, _ => {});            
+            Bind<IRotateComponent>(c => _rotateComponent = c, _ => {});
             _pixelPerfectComponent = AddComponent<IPixelPerfectComponent>();
-            Bind<IPixelPerfectComponent>(c => _pixelPerfectComponent = c, _ => {});            
+            Bind<IPixelPerfectComponent>(c => _pixelPerfectComponent = c, _ => {});
             _modelMatrixComponent = AddComponent<IModelMatrixComponent>();
-            Bind<IModelMatrixComponent>(c => _modelMatrixComponent = c, _ => {});            
+            Bind<IModelMatrixComponent>(c => _modelMatrixComponent = c, _ => {});
             _boundingBoxComponent = AddComponent<IBoundingBoxComponent>();
-            Bind<IBoundingBoxComponent>(c => _boundingBoxComponent = c, _ => {});            
+            Bind<IBoundingBoxComponent>(c => _boundingBoxComponent = c, _ => {});
+            _worldPositionComponent = AddComponent<IWorldPositionComponent>();
+            Bind<IWorldPositionComponent>(c => _worldPositionComponent = c, _ => {});
             _textComponent = AddComponent<ITextComponent>();
-            Bind<ITextComponent>(c => _textComponent = c, _ => {});            
+            Bind<ITextComponent>(c => _textComponent = c, _ => {});
             _buttonComponent = AddComponent<IButtonComponent>();
             Bind<IButtonComponent>(c => _buttonComponent = c, _ => {});
 			beforeInitComponents(resolver);
@@ -392,10 +395,10 @@ namespace AGS.Engine
             set { _imageComponent.Tint = value; } 
         }
 
-        public Vector4 Brightness
-        {
-            get { return _imageComponent.Brightness; }
-            set { _imageComponent.Brightness = value; }
+        public Vector4 Brightness 
+        {  
+            get { return _imageComponent.Brightness; }  
+            set { _imageComponent.Brightness = value; } 
         }
 
         public PointF Pivot 
@@ -501,15 +504,19 @@ namespace AGS.Engine
 
         #region IPixelPerfectComponent implementation
 
+        public Boolean IsPixelPerfect 
+        {  
+            get { return _pixelPerfectComponent.IsPixelPerfect; }  
+            set { _pixelPerfectComponent.IsPixelPerfect = value; } 
+        }
+
+        #endregion
+
+        #region IPixelPerfectCollidable implementation
+
         public IArea PixelPerfectHitTestArea 
         {  
             get { return _pixelPerfectComponent.PixelPerfectHitTestArea; } 
-        }
-
-        public bool IsPixelPerfect
-        {
-            get { return _pixelPerfectComponent.IsPixelPerfect; }
-            set { _pixelPerfectComponent.IsPixelPerfect = value; }
         }
 
         #endregion
@@ -535,6 +542,11 @@ namespace AGS.Engine
 
         #region IBoundingBoxComponent implementation
 
+        public AGSBoundingBox HitTestBoundingBox 
+        {  
+            get { return _boundingBoxComponent.HitTestBoundingBox; } 
+        }
+
         public IBlockingEvent OnBoundingBoxesChanged 
         {  
             get { return _boundingBoxComponent.OnBoundingBoxesChanged; } 
@@ -550,7 +562,19 @@ namespace AGS.Engine
             return _boundingBoxComponent.GetBoundingBoxes(viewport);
         }
 
-        public AGSBoundingBox HitTestBoundingBox { get { return _boundingBoxComponent.HitTestBoundingBox; } }
+        #endregion
+
+        #region IWorldPositionComponent implementation
+
+        public Single WorldX 
+        {  
+            get { return _worldPositionComponent.WorldX; } 
+        }
+
+        public Single WorldY 
+        {  
+            get { return _worldPositionComponent.WorldY; } 
+        }
 
         #endregion
 

--- a/Source/Engine/AGS.Engine/ComponentsFramework/Templates/AGSButton.generated.cs
+++ b/Source/Engine/AGS.Engine/ComponentsFramework/Templates/AGSButton.generated.cs
@@ -550,6 +550,8 @@ namespace AGS.Engine
             return _boundingBoxComponent.GetBoundingBoxes(viewport);
         }
 
+        public AGSBoundingBox HitTestBoundingBox { get { return _boundingBoxComponent.HitTestBoundingBox; } }
+
         #endregion
 
         #region ITextComponent implementation

--- a/Source/Engine/AGS.Engine/ComponentsFramework/Templates/AGSButton.generated.cs
+++ b/Source/Engine/AGS.Engine/ComponentsFramework/Templates/AGSButton.generated.cs
@@ -542,9 +542,9 @@ namespace AGS.Engine
 
         #region IBoundingBoxComponent implementation
 
-        public AGSBoundingBox HitTestBoundingBox 
+        public AGSBoundingBox WorldBoundingBox 
         {  
-            get { return _boundingBoxComponent.HitTestBoundingBox; } 
+            get { return _boundingBoxComponent.WorldBoundingBox; } 
         }
 
         public IBlockingEvent OnBoundingBoxesChanged 

--- a/Source/Engine/AGS.Engine/ComponentsFramework/Templates/AGSCharacter.generated.cs
+++ b/Source/Engine/AGS.Engine/ComponentsFramework/Templates/AGSCharacter.generated.cs
@@ -479,9 +479,9 @@ namespace AGS.Engine
 
         #region IBoundingBoxComponent implementation
 
-        public AGSBoundingBox HitTestBoundingBox 
+        public AGSBoundingBox WorldBoundingBox 
         {  
-            get { return _boundingBoxComponent.HitTestBoundingBox; } 
+            get { return _boundingBoxComponent.WorldBoundingBox; } 
         }
 
         public IBlockingEvent OnBoundingBoxesChanged 

--- a/Source/Engine/AGS.Engine/ComponentsFramework/Templates/AGSCharacter.generated.cs
+++ b/Source/Engine/AGS.Engine/ComponentsFramework/Templates/AGSCharacter.generated.cs
@@ -513,6 +513,11 @@ namespace AGS.Engine
             get { return _worldPositionComponent.WorldY; } 
         }
 
+        public PointF WorldXY
+        {
+            get { return _worldPositionComponent.WorldXY; }
+        }
+
         #endregion
 
         #region ISayComponent implementation

--- a/Source/Engine/AGS.Engine/ComponentsFramework/Templates/AGSCharacter.generated.cs
+++ b/Source/Engine/AGS.Engine/ComponentsFramework/Templates/AGSCharacter.generated.cs
@@ -487,6 +487,8 @@ namespace AGS.Engine
             return _boundingBoxComponent.GetBoundingBoxes(viewport);
         }
 
+        public AGSBoundingBox HitTestBoundingBox { get { return _boundingBoxComponent.HitTestBoundingBox; } }
+
         #endregion
 
         #region ISayComponent implementation

--- a/Source/Engine/AGS.Engine/ComponentsFramework/Templates/AGSCharacter.generated.cs
+++ b/Source/Engine/AGS.Engine/ComponentsFramework/Templates/AGSCharacter.generated.cs
@@ -31,6 +31,7 @@ namespace AGS.Engine
         private IPixelPerfectComponent _pixelPerfectComponent;
         private IModelMatrixComponent _modelMatrixComponent;
         private IBoundingBoxComponent _boundingBoxComponent;
+        private IWorldPositionComponent _worldPositionComponent;
         private ISayComponent _sayComponent;
         private IWalkComponent _walkComponent;
         private IFaceDirectionComponent _faceDirectionComponent;
@@ -40,47 +41,49 @@ namespace AGS.Engine
         private IHotspotComponent _hotspotComponent;
 
         public AGSCharacter(string id, Resolver resolver, IOutfit outfit) : base(id, resolver)
-        {            
+        {
             _hasRoomComponent = AddComponent<IHasRoomComponent>();
-            Bind<IHasRoomComponent>(c => _hasRoomComponent = c, _ => {});            
+            Bind<IHasRoomComponent>(c => _hasRoomComponent = c, _ => {});
             _animationComponent = AddComponent<IAnimationComponent>();
-            Bind<IAnimationComponent>(c => _animationComponent = c, _ => {});            
+            Bind<IAnimationComponent>(c => _animationComponent = c, _ => {});
             _inObjectTreeComponent = AddComponent<IInObjectTreeComponent>();
-            Bind<IInObjectTreeComponent>(c => _inObjectTreeComponent = c, _ => {});            
+            Bind<IInObjectTreeComponent>(c => _inObjectTreeComponent = c, _ => {});
             _colliderComponent = AddComponent<IColliderComponent>();
-            Bind<IColliderComponent>(c => _colliderComponent = c, _ => {});            
+            Bind<IColliderComponent>(c => _colliderComponent = c, _ => {});
             _visibleComponent = AddComponent<IVisibleComponent>();
-            Bind<IVisibleComponent>(c => _visibleComponent = c, _ => {});            
+            Bind<IVisibleComponent>(c => _visibleComponent = c, _ => {});
             _enabledComponent = AddComponent<IEnabledComponent>();
-            Bind<IEnabledComponent>(c => _enabledComponent = c, _ => {});            
+            Bind<IEnabledComponent>(c => _enabledComponent = c, _ => {});
             _customPropertiesComponent = AddComponent<ICustomPropertiesComponent>();
-            Bind<ICustomPropertiesComponent>(c => _customPropertiesComponent = c, _ => {});            
+            Bind<ICustomPropertiesComponent>(c => _customPropertiesComponent = c, _ => {});
             _drawableInfoComponent = AddComponent<IDrawableInfoComponent>();
-            Bind<IDrawableInfoComponent>(c => _drawableInfoComponent = c, _ => {});            
+            Bind<IDrawableInfoComponent>(c => _drawableInfoComponent = c, _ => {});
             _shaderComponent = AddComponent<IShaderComponent>();
-            Bind<IShaderComponent>(c => _shaderComponent = c, _ => {});            
+            Bind<IShaderComponent>(c => _shaderComponent = c, _ => {});
             _translateComponent = AddComponent<ITranslateComponent>();
-            Bind<ITranslateComponent>(c => _translateComponent = c, _ => {});            
+            Bind<ITranslateComponent>(c => _translateComponent = c, _ => {});
             _imageComponent = AddComponent<IImageComponent>();
-            Bind<IImageComponent>(c => _imageComponent = c, _ => {});            
+            Bind<IImageComponent>(c => _imageComponent = c, _ => {});
             _scaleComponent = AddComponent<IScaleComponent>();
-            Bind<IScaleComponent>(c => _scaleComponent = c, _ => {});            
+            Bind<IScaleComponent>(c => _scaleComponent = c, _ => {});
             _rotateComponent = AddComponent<IRotateComponent>();
-            Bind<IRotateComponent>(c => _rotateComponent = c, _ => {});            
+            Bind<IRotateComponent>(c => _rotateComponent = c, _ => {});
             _pixelPerfectComponent = AddComponent<IPixelPerfectComponent>();
-            Bind<IPixelPerfectComponent>(c => _pixelPerfectComponent = c, _ => {});            
+            Bind<IPixelPerfectComponent>(c => _pixelPerfectComponent = c, _ => {});
             _modelMatrixComponent = AddComponent<IModelMatrixComponent>();
-            Bind<IModelMatrixComponent>(c => _modelMatrixComponent = c, _ => {});            
+            Bind<IModelMatrixComponent>(c => _modelMatrixComponent = c, _ => {});
             _boundingBoxComponent = AddComponent<IBoundingBoxComponent>();
-            Bind<IBoundingBoxComponent>(c => _boundingBoxComponent = c, _ => {});            
+            Bind<IBoundingBoxComponent>(c => _boundingBoxComponent = c, _ => {});
+            _worldPositionComponent = AddComponent<IWorldPositionComponent>();
+            Bind<IWorldPositionComponent>(c => _worldPositionComponent = c, _ => {});
             _faceDirectionComponent = AddComponent<IFaceDirectionComponent>();
-            Bind<IFaceDirectionComponent>(c => _faceDirectionComponent = c, _ => {});            
+            Bind<IFaceDirectionComponent>(c => _faceDirectionComponent = c, _ => {});
             _outfitComponent = AddComponent<IOutfitComponent>();
-            Bind<IOutfitComponent>(c => _outfitComponent = c, _ => {});            
+            Bind<IOutfitComponent>(c => _outfitComponent = c, _ => {});
             _inventoryComponent = AddComponent<IInventoryComponent>();
-            Bind<IInventoryComponent>(c => _inventoryComponent = c, _ => {});            
+            Bind<IInventoryComponent>(c => _inventoryComponent = c, _ => {});
             _followComponent = AddComponent<IFollowComponent>();
-            Bind<IFollowComponent>(c => _followComponent = c, _ => {});            
+            Bind<IFollowComponent>(c => _followComponent = c, _ => {});
             _hotspotComponent = AddComponent<IHotspotComponent>();
             Bind<IHotspotComponent>(c => _hotspotComponent = c, _ => {});
 			beforeInitComponents(resolver, outfit);
@@ -329,10 +332,10 @@ namespace AGS.Engine
             set { _imageComponent.Tint = value; } 
         }
 
-        public Vector4 Brightness
-        {
-            get { return _imageComponent.Brightness; }
-            set { _imageComponent.Brightness = value; }
+        public Vector4 Brightness 
+        {  
+            get { return _imageComponent.Brightness; }  
+            set { _imageComponent.Brightness = value; } 
         }
 
         public PointF Pivot 
@@ -438,15 +441,19 @@ namespace AGS.Engine
 
         #region IPixelPerfectComponent implementation
 
+        public Boolean IsPixelPerfect 
+        {  
+            get { return _pixelPerfectComponent.IsPixelPerfect; }  
+            set { _pixelPerfectComponent.IsPixelPerfect = value; } 
+        }
+
+        #endregion
+
+        #region IPixelPerfectCollidable implementation
+
         public IArea PixelPerfectHitTestArea 
         {  
             get { return _pixelPerfectComponent.PixelPerfectHitTestArea; } 
-        }
-
-        public bool IsPixelPerfect
-        {
-            get { return _pixelPerfectComponent.IsPixelPerfect; }
-            set { _pixelPerfectComponent.IsPixelPerfect = value; }
         }
 
         #endregion
@@ -472,6 +479,11 @@ namespace AGS.Engine
 
         #region IBoundingBoxComponent implementation
 
+        public AGSBoundingBox HitTestBoundingBox 
+        {  
+            get { return _boundingBoxComponent.HitTestBoundingBox; } 
+        }
+
         public IBlockingEvent OnBoundingBoxesChanged 
         {  
             get { return _boundingBoxComponent.OnBoundingBoxesChanged; } 
@@ -487,7 +499,19 @@ namespace AGS.Engine
             return _boundingBoxComponent.GetBoundingBoxes(viewport);
         }
 
-        public AGSBoundingBox HitTestBoundingBox { get { return _boundingBoxComponent.HitTestBoundingBox; } }
+        #endregion
+
+        #region IWorldPositionComponent implementation
+
+        public Single WorldX 
+        {  
+            get { return _worldPositionComponent.WorldX; } 
+        }
+
+        public Single WorldY 
+        {  
+            get { return _worldPositionComponent.WorldY; } 
+        }
 
         #endregion
 

--- a/Source/Engine/AGS.Engine/ComponentsFramework/Templates/AGSCheckbox.generated.cs
+++ b/Source/Engine/AGS.Engine/ComponentsFramework/Templates/AGSCheckbox.generated.cs
@@ -573,6 +573,11 @@ namespace AGS.Engine
             get { return _worldPositionComponent.WorldY; } 
         }
 
+        public PointF WorldXY
+        {
+            get { return _worldPositionComponent.WorldXY; }
+        }
+
         #endregion
 
         #region ICheckboxComponent implementation

--- a/Source/Engine/AGS.Engine/ComponentsFramework/Templates/AGSCheckbox.generated.cs
+++ b/Source/Engine/AGS.Engine/ComponentsFramework/Templates/AGSCheckbox.generated.cs
@@ -539,9 +539,9 @@ namespace AGS.Engine
 
         #region IBoundingBoxComponent implementation
 
-        public AGSBoundingBox HitTestBoundingBox 
+        public AGSBoundingBox WorldBoundingBox 
         {  
-            get { return _boundingBoxComponent.HitTestBoundingBox; } 
+            get { return _boundingBoxComponent.WorldBoundingBox; } 
         }
 
         public IBlockingEvent OnBoundingBoxesChanged 

--- a/Source/Engine/AGS.Engine/ComponentsFramework/Templates/AGSCheckbox.generated.cs
+++ b/Source/Engine/AGS.Engine/ComponentsFramework/Templates/AGSCheckbox.generated.cs
@@ -547,6 +547,8 @@ namespace AGS.Engine
             return _boundingBoxComponent.GetBoundingBoxes(viewport);
         }
 
+        public AGSBoundingBox HitTestBoundingBox { get { return _boundingBoxComponent.HitTestBoundingBox; } }
+
         #endregion
 
         #region ICheckboxComponent implementation

--- a/Source/Engine/AGS.Engine/ComponentsFramework/Templates/AGSCheckbox.generated.cs
+++ b/Source/Engine/AGS.Engine/ComponentsFramework/Templates/AGSCheckbox.generated.cs
@@ -32,46 +32,49 @@ namespace AGS.Engine
         private IPixelPerfectComponent _pixelPerfectComponent;
         private IModelMatrixComponent _modelMatrixComponent;
         private IBoundingBoxComponent _boundingBoxComponent;
+        private IWorldPositionComponent _worldPositionComponent;
         private ICheckboxComponent _checkboxComponent;
 
         public AGSCheckBox(string id, Resolver resolver) : base(id, resolver)
-        {            
+        {
             _uIEvents = AddComponent<IUIEvents>();
-            Bind<IUIEvents>(c => _uIEvents = c, _ => {});            
+            Bind<IUIEvents>(c => _uIEvents = c, _ => {});
             _skinComponent = AddComponent<ISkinComponent>();
-            Bind<ISkinComponent>(c => _skinComponent = c, _ => {});            
+            Bind<ISkinComponent>(c => _skinComponent = c, _ => {});
             _hasRoomComponent = AddComponent<IHasRoomComponent>();
-            Bind<IHasRoomComponent>(c => _hasRoomComponent = c, _ => {});            
+            Bind<IHasRoomComponent>(c => _hasRoomComponent = c, _ => {});
             _animationComponent = AddComponent<IAnimationComponent>();
-            Bind<IAnimationComponent>(c => _animationComponent = c, _ => {});            
+            Bind<IAnimationComponent>(c => _animationComponent = c, _ => {});
             _inObjectTreeComponent = AddComponent<IInObjectTreeComponent>();
-            Bind<IInObjectTreeComponent>(c => _inObjectTreeComponent = c, _ => {});            
+            Bind<IInObjectTreeComponent>(c => _inObjectTreeComponent = c, _ => {});
             _colliderComponent = AddComponent<IColliderComponent>();
-            Bind<IColliderComponent>(c => _colliderComponent = c, _ => {});            
+            Bind<IColliderComponent>(c => _colliderComponent = c, _ => {});
             _visibleComponent = AddComponent<IVisibleComponent>();
-            Bind<IVisibleComponent>(c => _visibleComponent = c, _ => {});            
+            Bind<IVisibleComponent>(c => _visibleComponent = c, _ => {});
             _enabledComponent = AddComponent<IEnabledComponent>();
-            Bind<IEnabledComponent>(c => _enabledComponent = c, _ => {});            
+            Bind<IEnabledComponent>(c => _enabledComponent = c, _ => {});
             _customPropertiesComponent = AddComponent<ICustomPropertiesComponent>();
-            Bind<ICustomPropertiesComponent>(c => _customPropertiesComponent = c, _ => {});            
+            Bind<ICustomPropertiesComponent>(c => _customPropertiesComponent = c, _ => {});
             _drawableInfoComponent = AddComponent<IDrawableInfoComponent>();
-            Bind<IDrawableInfoComponent>(c => _drawableInfoComponent = c, _ => {});            
+            Bind<IDrawableInfoComponent>(c => _drawableInfoComponent = c, _ => {});
             _shaderComponent = AddComponent<IShaderComponent>();
-            Bind<IShaderComponent>(c => _shaderComponent = c, _ => {});            
+            Bind<IShaderComponent>(c => _shaderComponent = c, _ => {});
             _translateComponent = AddComponent<ITranslateComponent>();
-            Bind<ITranslateComponent>(c => _translateComponent = c, _ => {});            
+            Bind<ITranslateComponent>(c => _translateComponent = c, _ => {});
             _imageComponent = AddComponent<IImageComponent>();
-            Bind<IImageComponent>(c => _imageComponent = c, _ => {});            
+            Bind<IImageComponent>(c => _imageComponent = c, _ => {});
             _scaleComponent = AddComponent<IScaleComponent>();
-            Bind<IScaleComponent>(c => _scaleComponent = c, _ => {});            
+            Bind<IScaleComponent>(c => _scaleComponent = c, _ => {});
             _rotateComponent = AddComponent<IRotateComponent>();
-            Bind<IRotateComponent>(c => _rotateComponent = c, _ => {});            
+            Bind<IRotateComponent>(c => _rotateComponent = c, _ => {});
             _pixelPerfectComponent = AddComponent<IPixelPerfectComponent>();
-            Bind<IPixelPerfectComponent>(c => _pixelPerfectComponent = c, _ => {});            
+            Bind<IPixelPerfectComponent>(c => _pixelPerfectComponent = c, _ => {});
             _modelMatrixComponent = AddComponent<IModelMatrixComponent>();
-            Bind<IModelMatrixComponent>(c => _modelMatrixComponent = c, _ => {});            
+            Bind<IModelMatrixComponent>(c => _modelMatrixComponent = c, _ => {});
             _boundingBoxComponent = AddComponent<IBoundingBoxComponent>();
-            Bind<IBoundingBoxComponent>(c => _boundingBoxComponent = c, _ => {});            
+            Bind<IBoundingBoxComponent>(c => _boundingBoxComponent = c, _ => {});
+            _worldPositionComponent = AddComponent<IWorldPositionComponent>();
+            Bind<IWorldPositionComponent>(c => _worldPositionComponent = c, _ => {});
             _checkboxComponent = AddComponent<ICheckboxComponent>();
             Bind<ICheckboxComponent>(c => _checkboxComponent = c, _ => {});
 			beforeInitComponents(resolver);
@@ -389,10 +392,10 @@ namespace AGS.Engine
             set { _imageComponent.Tint = value; } 
         }
 
-        public Vector4 Brightness
-        {
-            get { return _imageComponent.Brightness; }
-            set { _imageComponent.Brightness = value; }
+        public Vector4 Brightness 
+        {  
+            get { return _imageComponent.Brightness; }  
+            set { _imageComponent.Brightness = value; } 
         }
 
         public PointF Pivot 
@@ -498,15 +501,19 @@ namespace AGS.Engine
 
         #region IPixelPerfectComponent implementation
 
+        public Boolean IsPixelPerfect 
+        {  
+            get { return _pixelPerfectComponent.IsPixelPerfect; }  
+            set { _pixelPerfectComponent.IsPixelPerfect = value; } 
+        }
+
+        #endregion
+
+        #region IPixelPerfectCollidable implementation
+
         public IArea PixelPerfectHitTestArea 
         {  
             get { return _pixelPerfectComponent.PixelPerfectHitTestArea; } 
-        }
-
-        public bool IsPixelPerfect
-        {
-            get { return _pixelPerfectComponent.IsPixelPerfect; }
-            set { _pixelPerfectComponent.IsPixelPerfect = value; }
         }
 
         #endregion
@@ -532,6 +539,11 @@ namespace AGS.Engine
 
         #region IBoundingBoxComponent implementation
 
+        public AGSBoundingBox HitTestBoundingBox 
+        {  
+            get { return _boundingBoxComponent.HitTestBoundingBox; } 
+        }
+
         public IBlockingEvent OnBoundingBoxesChanged 
         {  
             get { return _boundingBoxComponent.OnBoundingBoxesChanged; } 
@@ -547,7 +559,19 @@ namespace AGS.Engine
             return _boundingBoxComponent.GetBoundingBoxes(viewport);
         }
 
-        public AGSBoundingBox HitTestBoundingBox { get { return _boundingBoxComponent.HitTestBoundingBox; } }
+        #endregion
+
+        #region IWorldPositionComponent implementation
+
+        public Single WorldX 
+        {  
+            get { return _worldPositionComponent.WorldX; } 
+        }
+
+        public Single WorldY 
+        {  
+            get { return _worldPositionComponent.WorldY; } 
+        }
 
         #endregion
 

--- a/Source/Engine/AGS.Engine/ComponentsFramework/Templates/AGSComboBox.generated.cs
+++ b/Source/Engine/AGS.Engine/ComponentsFramework/Templates/AGSComboBox.generated.cs
@@ -578,9 +578,9 @@ namespace AGS.Engine
 
         #region IBoundingBoxComponent implementation
 
-        public AGSBoundingBox HitTestBoundingBox 
+        public AGSBoundingBox WorldBoundingBox 
         {  
-            get { return _boundingBoxComponent.HitTestBoundingBox; } 
+            get { return _boundingBoxComponent.WorldBoundingBox; } 
         }
 
         public IBlockingEvent OnBoundingBoxesChanged 

--- a/Source/Engine/AGS.Engine/ComponentsFramework/Templates/AGSComboBox.generated.cs
+++ b/Source/Engine/AGS.Engine/ComponentsFramework/Templates/AGSComboBox.generated.cs
@@ -33,47 +33,50 @@ namespace AGS.Engine
         private IPixelPerfectComponent _pixelPerfectComponent;
         private IModelMatrixComponent _modelMatrixComponent;
         private IBoundingBoxComponent _boundingBoxComponent;
+        private IWorldPositionComponent _worldPositionComponent;
 
         public AGSComboBox(string id, Resolver resolver) : base(id, resolver)
-        {            
+        {
             _comboBoxComponent = AddComponent<IComboBoxComponent>();
-            Bind<IComboBoxComponent>(c => _comboBoxComponent = c, _ => {});            
+            Bind<IComboBoxComponent>(c => _comboBoxComponent = c, _ => {});
             _uIEvents = AddComponent<IUIEvents>();
-            Bind<IUIEvents>(c => _uIEvents = c, _ => {});            
+            Bind<IUIEvents>(c => _uIEvents = c, _ => {});
             _skinComponent = AddComponent<ISkinComponent>();
-            Bind<ISkinComponent>(c => _skinComponent = c, _ => {});            
+            Bind<ISkinComponent>(c => _skinComponent = c, _ => {});
             _hasRoomComponent = AddComponent<IHasRoomComponent>();
-            Bind<IHasRoomComponent>(c => _hasRoomComponent = c, _ => {});            
+            Bind<IHasRoomComponent>(c => _hasRoomComponent = c, _ => {});
             _animationComponent = AddComponent<IAnimationComponent>();
-            Bind<IAnimationComponent>(c => _animationComponent = c, _ => {});            
+            Bind<IAnimationComponent>(c => _animationComponent = c, _ => {});
             _inObjectTreeComponent = AddComponent<IInObjectTreeComponent>();
-            Bind<IInObjectTreeComponent>(c => _inObjectTreeComponent = c, _ => {});            
+            Bind<IInObjectTreeComponent>(c => _inObjectTreeComponent = c, _ => {});
             _colliderComponent = AddComponent<IColliderComponent>();
-            Bind<IColliderComponent>(c => _colliderComponent = c, _ => {});            
+            Bind<IColliderComponent>(c => _colliderComponent = c, _ => {});
             _visibleComponent = AddComponent<IVisibleComponent>();
-            Bind<IVisibleComponent>(c => _visibleComponent = c, _ => {});            
+            Bind<IVisibleComponent>(c => _visibleComponent = c, _ => {});
             _enabledComponent = AddComponent<IEnabledComponent>();
-            Bind<IEnabledComponent>(c => _enabledComponent = c, _ => {});            
+            Bind<IEnabledComponent>(c => _enabledComponent = c, _ => {});
             _customPropertiesComponent = AddComponent<ICustomPropertiesComponent>();
-            Bind<ICustomPropertiesComponent>(c => _customPropertiesComponent = c, _ => {});            
+            Bind<ICustomPropertiesComponent>(c => _customPropertiesComponent = c, _ => {});
             _drawableInfoComponent = AddComponent<IDrawableInfoComponent>();
-            Bind<IDrawableInfoComponent>(c => _drawableInfoComponent = c, _ => {});            
+            Bind<IDrawableInfoComponent>(c => _drawableInfoComponent = c, _ => {});
             _shaderComponent = AddComponent<IShaderComponent>();
-            Bind<IShaderComponent>(c => _shaderComponent = c, _ => {});            
+            Bind<IShaderComponent>(c => _shaderComponent = c, _ => {});
             _translateComponent = AddComponent<ITranslateComponent>();
-            Bind<ITranslateComponent>(c => _translateComponent = c, _ => {});            
+            Bind<ITranslateComponent>(c => _translateComponent = c, _ => {});
             _imageComponent = AddComponent<IImageComponent>();
-            Bind<IImageComponent>(c => _imageComponent = c, _ => {});            
+            Bind<IImageComponent>(c => _imageComponent = c, _ => {});
             _scaleComponent = AddComponent<IScaleComponent>();
-            Bind<IScaleComponent>(c => _scaleComponent = c, _ => {});            
+            Bind<IScaleComponent>(c => _scaleComponent = c, _ => {});
             _rotateComponent = AddComponent<IRotateComponent>();
-            Bind<IRotateComponent>(c => _rotateComponent = c, _ => {});            
+            Bind<IRotateComponent>(c => _rotateComponent = c, _ => {});
             _pixelPerfectComponent = AddComponent<IPixelPerfectComponent>();
-            Bind<IPixelPerfectComponent>(c => _pixelPerfectComponent = c, _ => {});            
+            Bind<IPixelPerfectComponent>(c => _pixelPerfectComponent = c, _ => {});
             _modelMatrixComponent = AddComponent<IModelMatrixComponent>();
-            Bind<IModelMatrixComponent>(c => _modelMatrixComponent = c, _ => {});            
+            Bind<IModelMatrixComponent>(c => _modelMatrixComponent = c, _ => {});
             _boundingBoxComponent = AddComponent<IBoundingBoxComponent>();
             Bind<IBoundingBoxComponent>(c => _boundingBoxComponent = c, _ => {});
+            _worldPositionComponent = AddComponent<IWorldPositionComponent>();
+            Bind<IWorldPositionComponent>(c => _worldPositionComponent = c, _ => {});
 			beforeInitComponents(resolver);
             InitComponents();
             afterInitComponents(resolver);
@@ -428,10 +431,10 @@ namespace AGS.Engine
             set { _imageComponent.Tint = value; } 
         }
 
-        public Vector4 Brightness
-        {
-            get { return _imageComponent.Brightness; }
-            set { _imageComponent.Brightness = value; }
+        public Vector4 Brightness 
+        {  
+            get { return _imageComponent.Brightness; }  
+            set { _imageComponent.Brightness = value; } 
         }
 
         public PointF Pivot 
@@ -537,15 +540,19 @@ namespace AGS.Engine
 
         #region IPixelPerfectComponent implementation
 
+        public Boolean IsPixelPerfect 
+        {  
+            get { return _pixelPerfectComponent.IsPixelPerfect; }  
+            set { _pixelPerfectComponent.IsPixelPerfect = value; } 
+        }
+
+        #endregion
+
+        #region IPixelPerfectCollidable implementation
+
         public IArea PixelPerfectHitTestArea 
         {  
             get { return _pixelPerfectComponent.PixelPerfectHitTestArea; } 
-        }
-
-        public bool IsPixelPerfect
-        {
-            get { return _pixelPerfectComponent.IsPixelPerfect; }
-            set { _pixelPerfectComponent.IsPixelPerfect = value; }
         }
 
         #endregion
@@ -571,6 +578,11 @@ namespace AGS.Engine
 
         #region IBoundingBoxComponent implementation
 
+        public AGSBoundingBox HitTestBoundingBox 
+        {  
+            get { return _boundingBoxComponent.HitTestBoundingBox; } 
+        }
+
         public IBlockingEvent OnBoundingBoxesChanged 
         {  
             get { return _boundingBoxComponent.OnBoundingBoxesChanged; } 
@@ -586,7 +598,19 @@ namespace AGS.Engine
             return _boundingBoxComponent.GetBoundingBoxes(viewport);
         }
 
-        public AGSBoundingBox HitTestBoundingBox { get { return _boundingBoxComponent.HitTestBoundingBox; } }
+        #endregion
+
+        #region IWorldPositionComponent implementation
+
+        public Single WorldX 
+        {  
+            get { return _worldPositionComponent.WorldX; } 
+        }
+
+        public Single WorldY 
+        {  
+            get { return _worldPositionComponent.WorldY; } 
+        }
 
         #endregion
     }

--- a/Source/Engine/AGS.Engine/ComponentsFramework/Templates/AGSComboBox.generated.cs
+++ b/Source/Engine/AGS.Engine/ComponentsFramework/Templates/AGSComboBox.generated.cs
@@ -612,6 +612,11 @@ namespace AGS.Engine
             get { return _worldPositionComponent.WorldY; } 
         }
 
+        public PointF WorldXY
+        {
+            get { return _worldPositionComponent.WorldXY; }
+        }
+
         #endregion
     }
 }

--- a/Source/Engine/AGS.Engine/ComponentsFramework/Templates/AGSComboBox.generated.cs
+++ b/Source/Engine/AGS.Engine/ComponentsFramework/Templates/AGSComboBox.generated.cs
@@ -586,6 +586,8 @@ namespace AGS.Engine
             return _boundingBoxComponent.GetBoundingBoxes(viewport);
         }
 
+        public AGSBoundingBox HitTestBoundingBox { get { return _boundingBoxComponent.HitTestBoundingBox; } }
+
         #endregion
     }
 }

--- a/Source/Engine/AGS.Engine/ComponentsFramework/Templates/AGSInventoryWindow.generated.cs
+++ b/Source/Engine/AGS.Engine/ComponentsFramework/Templates/AGSInventoryWindow.generated.cs
@@ -547,6 +547,8 @@ namespace AGS.Engine
             return _boundingBoxComponent.GetBoundingBoxes(viewport);
         }
 
+        public AGSBoundingBox HitTestBoundingBox { get { return _boundingBoxComponent.HitTestBoundingBox; } }
+
         #endregion
 
         #region IInventoryWindowComponent implementation

--- a/Source/Engine/AGS.Engine/ComponentsFramework/Templates/AGSInventoryWindow.generated.cs
+++ b/Source/Engine/AGS.Engine/ComponentsFramework/Templates/AGSInventoryWindow.generated.cs
@@ -539,9 +539,9 @@ namespace AGS.Engine
 
         #region IBoundingBoxComponent implementation
 
-        public AGSBoundingBox HitTestBoundingBox 
+        public AGSBoundingBox WorldBoundingBox 
         {  
-            get { return _boundingBoxComponent.HitTestBoundingBox; } 
+            get { return _boundingBoxComponent.WorldBoundingBox; } 
         }
 
         public IBlockingEvent OnBoundingBoxesChanged 

--- a/Source/Engine/AGS.Engine/ComponentsFramework/Templates/AGSInventoryWindow.generated.cs
+++ b/Source/Engine/AGS.Engine/ComponentsFramework/Templates/AGSInventoryWindow.generated.cs
@@ -573,6 +573,11 @@ namespace AGS.Engine
             get { return _worldPositionComponent.WorldY; } 
         }
 
+        public PointF WorldXY
+        {
+            get { return _worldPositionComponent.WorldXY; }
+        }
+
         #endregion
 
         #region IInventoryWindowComponent implementation

--- a/Source/Engine/AGS.Engine/ComponentsFramework/Templates/AGSInventoryWindow.generated.cs
+++ b/Source/Engine/AGS.Engine/ComponentsFramework/Templates/AGSInventoryWindow.generated.cs
@@ -32,46 +32,49 @@ namespace AGS.Engine
         private IPixelPerfectComponent _pixelPerfectComponent;
         private IModelMatrixComponent _modelMatrixComponent;
         private IBoundingBoxComponent _boundingBoxComponent;
+        private IWorldPositionComponent _worldPositionComponent;
         private IInventoryWindowComponent _inventoryWindowComponent;
 
         public AGSInventoryWindow(string id, Resolver resolver, IImage image) : base(id, resolver)
-        {            
+        {
             _uIEvents = AddComponent<IUIEvents>();
-            Bind<IUIEvents>(c => _uIEvents = c, _ => {});            
+            Bind<IUIEvents>(c => _uIEvents = c, _ => {});
             _skinComponent = AddComponent<ISkinComponent>();
-            Bind<ISkinComponent>(c => _skinComponent = c, _ => {});            
+            Bind<ISkinComponent>(c => _skinComponent = c, _ => {});
             _hasRoomComponent = AddComponent<IHasRoomComponent>();
-            Bind<IHasRoomComponent>(c => _hasRoomComponent = c, _ => {});            
+            Bind<IHasRoomComponent>(c => _hasRoomComponent = c, _ => {});
             _animationComponent = AddComponent<IAnimationComponent>();
-            Bind<IAnimationComponent>(c => _animationComponent = c, _ => {});            
+            Bind<IAnimationComponent>(c => _animationComponent = c, _ => {});
             _inObjectTreeComponent = AddComponent<IInObjectTreeComponent>();
-            Bind<IInObjectTreeComponent>(c => _inObjectTreeComponent = c, _ => {});            
+            Bind<IInObjectTreeComponent>(c => _inObjectTreeComponent = c, _ => {});
             _colliderComponent = AddComponent<IColliderComponent>();
-            Bind<IColliderComponent>(c => _colliderComponent = c, _ => {});            
+            Bind<IColliderComponent>(c => _colliderComponent = c, _ => {});
             _visibleComponent = AddComponent<IVisibleComponent>();
-            Bind<IVisibleComponent>(c => _visibleComponent = c, _ => {});            
+            Bind<IVisibleComponent>(c => _visibleComponent = c, _ => {});
             _enabledComponent = AddComponent<IEnabledComponent>();
-            Bind<IEnabledComponent>(c => _enabledComponent = c, _ => {});            
+            Bind<IEnabledComponent>(c => _enabledComponent = c, _ => {});
             _customPropertiesComponent = AddComponent<ICustomPropertiesComponent>();
-            Bind<ICustomPropertiesComponent>(c => _customPropertiesComponent = c, _ => {});            
+            Bind<ICustomPropertiesComponent>(c => _customPropertiesComponent = c, _ => {});
             _drawableInfoComponent = AddComponent<IDrawableInfoComponent>();
-            Bind<IDrawableInfoComponent>(c => _drawableInfoComponent = c, _ => {});            
+            Bind<IDrawableInfoComponent>(c => _drawableInfoComponent = c, _ => {});
             _shaderComponent = AddComponent<IShaderComponent>();
-            Bind<IShaderComponent>(c => _shaderComponent = c, _ => {});            
+            Bind<IShaderComponent>(c => _shaderComponent = c, _ => {});
             _translateComponent = AddComponent<ITranslateComponent>();
-            Bind<ITranslateComponent>(c => _translateComponent = c, _ => {});            
+            Bind<ITranslateComponent>(c => _translateComponent = c, _ => {});
             _imageComponent = AddComponent<IImageComponent>();
-            Bind<IImageComponent>(c => _imageComponent = c, _ => {});            
+            Bind<IImageComponent>(c => _imageComponent = c, _ => {});
             _scaleComponent = AddComponent<IScaleComponent>();
-            Bind<IScaleComponent>(c => _scaleComponent = c, _ => {});            
+            Bind<IScaleComponent>(c => _scaleComponent = c, _ => {});
             _rotateComponent = AddComponent<IRotateComponent>();
-            Bind<IRotateComponent>(c => _rotateComponent = c, _ => {});            
+            Bind<IRotateComponent>(c => _rotateComponent = c, _ => {});
             _pixelPerfectComponent = AddComponent<IPixelPerfectComponent>();
-            Bind<IPixelPerfectComponent>(c => _pixelPerfectComponent = c, _ => {});            
+            Bind<IPixelPerfectComponent>(c => _pixelPerfectComponent = c, _ => {});
             _modelMatrixComponent = AddComponent<IModelMatrixComponent>();
-            Bind<IModelMatrixComponent>(c => _modelMatrixComponent = c, _ => {});            
+            Bind<IModelMatrixComponent>(c => _modelMatrixComponent = c, _ => {});
             _boundingBoxComponent = AddComponent<IBoundingBoxComponent>();
-            Bind<IBoundingBoxComponent>(c => _boundingBoxComponent = c, _ => {});            
+            Bind<IBoundingBoxComponent>(c => _boundingBoxComponent = c, _ => {});
+            _worldPositionComponent = AddComponent<IWorldPositionComponent>();
+            Bind<IWorldPositionComponent>(c => _worldPositionComponent = c, _ => {});
             _inventoryWindowComponent = AddComponent<IInventoryWindowComponent>();
             Bind<IInventoryWindowComponent>(c => _inventoryWindowComponent = c, _ => {});
 			beforeInitComponents(resolver, image);
@@ -389,10 +392,10 @@ namespace AGS.Engine
             set { _imageComponent.Tint = value; } 
         }
 
-        public Vector4 Brightness
-        {
-            get { return _imageComponent.Brightness; }
-            set { _imageComponent.Brightness = value; }
+        public Vector4 Brightness 
+        {  
+            get { return _imageComponent.Brightness; }  
+            set { _imageComponent.Brightness = value; } 
         }
 
         public PointF Pivot 
@@ -498,15 +501,19 @@ namespace AGS.Engine
 
         #region IPixelPerfectComponent implementation
 
+        public Boolean IsPixelPerfect 
+        {  
+            get { return _pixelPerfectComponent.IsPixelPerfect; }  
+            set { _pixelPerfectComponent.IsPixelPerfect = value; } 
+        }
+
+        #endregion
+
+        #region IPixelPerfectCollidable implementation
+
         public IArea PixelPerfectHitTestArea 
         {  
             get { return _pixelPerfectComponent.PixelPerfectHitTestArea; } 
-        }
-
-        public bool IsPixelPerfect
-        {
-            get { return _pixelPerfectComponent.IsPixelPerfect; }
-            set { _pixelPerfectComponent.IsPixelPerfect = value; }
         }
 
         #endregion
@@ -532,6 +539,11 @@ namespace AGS.Engine
 
         #region IBoundingBoxComponent implementation
 
+        public AGSBoundingBox HitTestBoundingBox 
+        {  
+            get { return _boundingBoxComponent.HitTestBoundingBox; } 
+        }
+
         public IBlockingEvent OnBoundingBoxesChanged 
         {  
             get { return _boundingBoxComponent.OnBoundingBoxesChanged; } 
@@ -547,7 +559,19 @@ namespace AGS.Engine
             return _boundingBoxComponent.GetBoundingBoxes(viewport);
         }
 
-        public AGSBoundingBox HitTestBoundingBox { get { return _boundingBoxComponent.HitTestBoundingBox; } }
+        #endregion
+
+        #region IWorldPositionComponent implementation
+
+        public Single WorldX 
+        {  
+            get { return _worldPositionComponent.WorldX; } 
+        }
+
+        public Single WorldY 
+        {  
+            get { return _worldPositionComponent.WorldY; } 
+        }
 
         #endregion
 

--- a/Source/Engine/AGS.Engine/ComponentsFramework/Templates/AGSLabel.generated.cs
+++ b/Source/Engine/AGS.Engine/ComponentsFramework/Templates/AGSLabel.generated.cs
@@ -617,6 +617,11 @@ namespace AGS.Engine
             get { return _worldPositionComponent.WorldY; } 
         }
 
+        public PointF WorldXY
+        {
+            get { return _worldPositionComponent.WorldXY; }
+        }
+
         #endregion
     }
 }

--- a/Source/Engine/AGS.Engine/ComponentsFramework/Templates/AGSLabel.generated.cs
+++ b/Source/Engine/AGS.Engine/ComponentsFramework/Templates/AGSLabel.generated.cs
@@ -591,6 +591,8 @@ namespace AGS.Engine
             return _boundingBoxComponent.GetBoundingBoxes(viewport);
         }
 
+        public AGSBoundingBox HitTestBoundingBox { get { return _boundingBoxComponent.HitTestBoundingBox; } }
+
         #endregion
     }
 }

--- a/Source/Engine/AGS.Engine/ComponentsFramework/Templates/AGSLabel.generated.cs
+++ b/Source/Engine/AGS.Engine/ComponentsFramework/Templates/AGSLabel.generated.cs
@@ -583,9 +583,9 @@ namespace AGS.Engine
 
         #region IBoundingBoxComponent implementation
 
-        public AGSBoundingBox HitTestBoundingBox 
+        public AGSBoundingBox WorldBoundingBox 
         {  
-            get { return _boundingBoxComponent.HitTestBoundingBox; } 
+            get { return _boundingBoxComponent.WorldBoundingBox; } 
         }
 
         public IBlockingEvent OnBoundingBoxesChanged 

--- a/Source/Engine/AGS.Engine/ComponentsFramework/Templates/AGSLabel.generated.cs
+++ b/Source/Engine/AGS.Engine/ComponentsFramework/Templates/AGSLabel.generated.cs
@@ -33,47 +33,50 @@ namespace AGS.Engine
         private IPixelPerfectComponent _pixelPerfectComponent;
         private IModelMatrixComponent _modelMatrixComponent;
         private IBoundingBoxComponent _boundingBoxComponent;
+        private IWorldPositionComponent _worldPositionComponent;
 
         public AGSLabel(string id, Resolver resolver) : base(id, resolver)
-        {            
+        {
             _textComponent = AddComponent<ITextComponent>();
-            Bind<ITextComponent>(c => _textComponent = c, _ => {});            
+            Bind<ITextComponent>(c => _textComponent = c, _ => {});
             _uIEvents = AddComponent<IUIEvents>();
-            Bind<IUIEvents>(c => _uIEvents = c, _ => {});            
+            Bind<IUIEvents>(c => _uIEvents = c, _ => {});
             _skinComponent = AddComponent<ISkinComponent>();
-            Bind<ISkinComponent>(c => _skinComponent = c, _ => {});            
+            Bind<ISkinComponent>(c => _skinComponent = c, _ => {});
             _hasRoomComponent = AddComponent<IHasRoomComponent>();
-            Bind<IHasRoomComponent>(c => _hasRoomComponent = c, _ => {});            
+            Bind<IHasRoomComponent>(c => _hasRoomComponent = c, _ => {});
             _animationComponent = AddComponent<IAnimationComponent>();
-            Bind<IAnimationComponent>(c => _animationComponent = c, _ => {});            
+            Bind<IAnimationComponent>(c => _animationComponent = c, _ => {});
             _inObjectTreeComponent = AddComponent<IInObjectTreeComponent>();
-            Bind<IInObjectTreeComponent>(c => _inObjectTreeComponent = c, _ => {});            
+            Bind<IInObjectTreeComponent>(c => _inObjectTreeComponent = c, _ => {});
             _colliderComponent = AddComponent<IColliderComponent>();
-            Bind<IColliderComponent>(c => _colliderComponent = c, _ => {});            
+            Bind<IColliderComponent>(c => _colliderComponent = c, _ => {});
             _visibleComponent = AddComponent<IVisibleComponent>();
-            Bind<IVisibleComponent>(c => _visibleComponent = c, _ => {});            
+            Bind<IVisibleComponent>(c => _visibleComponent = c, _ => {});
             _enabledComponent = AddComponent<IEnabledComponent>();
-            Bind<IEnabledComponent>(c => _enabledComponent = c, _ => {});            
+            Bind<IEnabledComponent>(c => _enabledComponent = c, _ => {});
             _customPropertiesComponent = AddComponent<ICustomPropertiesComponent>();
-            Bind<ICustomPropertiesComponent>(c => _customPropertiesComponent = c, _ => {});            
+            Bind<ICustomPropertiesComponent>(c => _customPropertiesComponent = c, _ => {});
             _drawableInfoComponent = AddComponent<IDrawableInfoComponent>();
-            Bind<IDrawableInfoComponent>(c => _drawableInfoComponent = c, _ => {});            
+            Bind<IDrawableInfoComponent>(c => _drawableInfoComponent = c, _ => {});
             _shaderComponent = AddComponent<IShaderComponent>();
-            Bind<IShaderComponent>(c => _shaderComponent = c, _ => {});            
+            Bind<IShaderComponent>(c => _shaderComponent = c, _ => {});
             _translateComponent = AddComponent<ITranslateComponent>();
-            Bind<ITranslateComponent>(c => _translateComponent = c, _ => {});            
+            Bind<ITranslateComponent>(c => _translateComponent = c, _ => {});
             _imageComponent = AddComponent<IImageComponent>();
-            Bind<IImageComponent>(c => _imageComponent = c, _ => {});            
+            Bind<IImageComponent>(c => _imageComponent = c, _ => {});
             _scaleComponent = AddComponent<IScaleComponent>();
-            Bind<IScaleComponent>(c => _scaleComponent = c, _ => {});            
+            Bind<IScaleComponent>(c => _scaleComponent = c, _ => {});
             _rotateComponent = AddComponent<IRotateComponent>();
-            Bind<IRotateComponent>(c => _rotateComponent = c, _ => {});            
+            Bind<IRotateComponent>(c => _rotateComponent = c, _ => {});
             _pixelPerfectComponent = AddComponent<IPixelPerfectComponent>();
-            Bind<IPixelPerfectComponent>(c => _pixelPerfectComponent = c, _ => {});            
+            Bind<IPixelPerfectComponent>(c => _pixelPerfectComponent = c, _ => {});
             _modelMatrixComponent = AddComponent<IModelMatrixComponent>();
-            Bind<IModelMatrixComponent>(c => _modelMatrixComponent = c, _ => {});            
+            Bind<IModelMatrixComponent>(c => _modelMatrixComponent = c, _ => {});
             _boundingBoxComponent = AddComponent<IBoundingBoxComponent>();
             Bind<IBoundingBoxComponent>(c => _boundingBoxComponent = c, _ => {});
+            _worldPositionComponent = AddComponent<IWorldPositionComponent>();
+            Bind<IWorldPositionComponent>(c => _worldPositionComponent = c, _ => {});
 			beforeInitComponents(resolver);
             InitComponents();
             afterInitComponents(resolver);
@@ -433,10 +436,10 @@ namespace AGS.Engine
             set { _imageComponent.Tint = value; } 
         }
 
-        public Vector4 Brightness
-        {
-            get { return _imageComponent.Brightness; }
-            set { _imageComponent.Brightness = value; }
+        public Vector4 Brightness 
+        {  
+            get { return _imageComponent.Brightness; }  
+            set { _imageComponent.Brightness = value; } 
         }
 
         public PointF Pivot 
@@ -542,15 +545,19 @@ namespace AGS.Engine
 
         #region IPixelPerfectComponent implementation
 
+        public Boolean IsPixelPerfect 
+        {  
+            get { return _pixelPerfectComponent.IsPixelPerfect; }  
+            set { _pixelPerfectComponent.IsPixelPerfect = value; } 
+        }
+
+        #endregion
+
+        #region IPixelPerfectCollidable implementation
+
         public IArea PixelPerfectHitTestArea 
         {  
             get { return _pixelPerfectComponent.PixelPerfectHitTestArea; } 
-        }
-
-        public bool IsPixelPerfect
-        {
-            get { return _pixelPerfectComponent.IsPixelPerfect; }
-            set { _pixelPerfectComponent.IsPixelPerfect = value; }
         }
 
         #endregion
@@ -576,6 +583,11 @@ namespace AGS.Engine
 
         #region IBoundingBoxComponent implementation
 
+        public AGSBoundingBox HitTestBoundingBox 
+        {  
+            get { return _boundingBoxComponent.HitTestBoundingBox; } 
+        }
+
         public IBlockingEvent OnBoundingBoxesChanged 
         {  
             get { return _boundingBoxComponent.OnBoundingBoxesChanged; } 
@@ -591,7 +603,19 @@ namespace AGS.Engine
             return _boundingBoxComponent.GetBoundingBoxes(viewport);
         }
 
-        public AGSBoundingBox HitTestBoundingBox { get { return _boundingBoxComponent.HitTestBoundingBox; } }
+        #endregion
+
+        #region IWorldPositionComponent implementation
+
+        public Single WorldX 
+        {  
+            get { return _worldPositionComponent.WorldX; } 
+        }
+
+        public Single WorldY 
+        {  
+            get { return _worldPositionComponent.WorldY; } 
+        }
 
         #endregion
     }

--- a/Source/Engine/AGS.Engine/ComponentsFramework/Templates/AGSObject.generated.cs
+++ b/Source/Engine/AGS.Engine/ComponentsFramework/Templates/AGSObject.generated.cs
@@ -500,6 +500,11 @@ namespace AGS.Engine
             get { return _worldPositionComponent.WorldY; } 
         }
 
+        public PointF WorldXY
+        {
+            get { return _worldPositionComponent.WorldXY; }
+        }
+
         #endregion
     }
 }

--- a/Source/Engine/AGS.Engine/ComponentsFramework/Templates/AGSObject.generated.cs
+++ b/Source/Engine/AGS.Engine/ComponentsFramework/Templates/AGSObject.generated.cs
@@ -30,41 +30,44 @@ namespace AGS.Engine
         private IPixelPerfectComponent _pixelPerfectComponent;
         private IModelMatrixComponent _modelMatrixComponent;
         private IBoundingBoxComponent _boundingBoxComponent;
+        private IWorldPositionComponent _worldPositionComponent;
 
         public AGSObject(string id, Resolver resolver) : base(id, resolver)
-        {            
+        {
             _hasRoomComponent = AddComponent<IHasRoomComponent>();
-            Bind<IHasRoomComponent>(c => _hasRoomComponent = c, _ => {});            
+            Bind<IHasRoomComponent>(c => _hasRoomComponent = c, _ => {});
             _animationComponent = AddComponent<IAnimationComponent>();
-            Bind<IAnimationComponent>(c => _animationComponent = c, _ => {});            
+            Bind<IAnimationComponent>(c => _animationComponent = c, _ => {});
             _inObjectTreeComponent = AddComponent<IInObjectTreeComponent>();
-            Bind<IInObjectTreeComponent>(c => _inObjectTreeComponent = c, _ => {});            
+            Bind<IInObjectTreeComponent>(c => _inObjectTreeComponent = c, _ => {});
             _colliderComponent = AddComponent<IColliderComponent>();
-            Bind<IColliderComponent>(c => _colliderComponent = c, _ => {});            
+            Bind<IColliderComponent>(c => _colliderComponent = c, _ => {});
             _visibleComponent = AddComponent<IVisibleComponent>();
-            Bind<IVisibleComponent>(c => _visibleComponent = c, _ => {});            
+            Bind<IVisibleComponent>(c => _visibleComponent = c, _ => {});
             _enabledComponent = AddComponent<IEnabledComponent>();
-            Bind<IEnabledComponent>(c => _enabledComponent = c, _ => {});            
+            Bind<IEnabledComponent>(c => _enabledComponent = c, _ => {});
             _customPropertiesComponent = AddComponent<ICustomPropertiesComponent>();
-            Bind<ICustomPropertiesComponent>(c => _customPropertiesComponent = c, _ => {});            
+            Bind<ICustomPropertiesComponent>(c => _customPropertiesComponent = c, _ => {});
             _drawableInfoComponent = AddComponent<IDrawableInfoComponent>();
-            Bind<IDrawableInfoComponent>(c => _drawableInfoComponent = c, _ => {});            
+            Bind<IDrawableInfoComponent>(c => _drawableInfoComponent = c, _ => {});
             _shaderComponent = AddComponent<IShaderComponent>();
-            Bind<IShaderComponent>(c => _shaderComponent = c, _ => {});            
+            Bind<IShaderComponent>(c => _shaderComponent = c, _ => {});
             _translateComponent = AddComponent<ITranslateComponent>();
-            Bind<ITranslateComponent>(c => _translateComponent = c, _ => {});            
+            Bind<ITranslateComponent>(c => _translateComponent = c, _ => {});
             _imageComponent = AddComponent<IImageComponent>();
-            Bind<IImageComponent>(c => _imageComponent = c, _ => {});            
+            Bind<IImageComponent>(c => _imageComponent = c, _ => {});
             _scaleComponent = AddComponent<IScaleComponent>();
-            Bind<IScaleComponent>(c => _scaleComponent = c, _ => {});            
+            Bind<IScaleComponent>(c => _scaleComponent = c, _ => {});
             _rotateComponent = AddComponent<IRotateComponent>();
-            Bind<IRotateComponent>(c => _rotateComponent = c, _ => {});            
+            Bind<IRotateComponent>(c => _rotateComponent = c, _ => {});
             _pixelPerfectComponent = AddComponent<IPixelPerfectComponent>();
-            Bind<IPixelPerfectComponent>(c => _pixelPerfectComponent = c, _ => {});            
+            Bind<IPixelPerfectComponent>(c => _pixelPerfectComponent = c, _ => {});
             _modelMatrixComponent = AddComponent<IModelMatrixComponent>();
-            Bind<IModelMatrixComponent>(c => _modelMatrixComponent = c, _ => {});            
+            Bind<IModelMatrixComponent>(c => _modelMatrixComponent = c, _ => {});
             _boundingBoxComponent = AddComponent<IBoundingBoxComponent>();
             Bind<IBoundingBoxComponent>(c => _boundingBoxComponent = c, _ => {});
+            _worldPositionComponent = AddComponent<IWorldPositionComponent>();
+            Bind<IWorldPositionComponent>(c => _worldPositionComponent = c, _ => {});
 			beforeInitComponents(resolver);
             InitComponents();
             afterInitComponents(resolver);
@@ -316,10 +319,10 @@ namespace AGS.Engine
             set { _imageComponent.Tint = value; } 
         }
 
-        public Vector4 Brightness
-        {
-            get { return _imageComponent.Brightness; }
-            set { _imageComponent.Brightness = value; }
+        public Vector4 Brightness 
+        {  
+            get { return _imageComponent.Brightness; }  
+            set { _imageComponent.Brightness = value; } 
         }
 
         public PointF Pivot 
@@ -425,15 +428,19 @@ namespace AGS.Engine
 
         #region IPixelPerfectComponent implementation
 
+        public Boolean IsPixelPerfect 
+        {  
+            get { return _pixelPerfectComponent.IsPixelPerfect; }  
+            set { _pixelPerfectComponent.IsPixelPerfect = value; } 
+        }
+
+        #endregion
+
+        #region IPixelPerfectCollidable implementation
+
         public IArea PixelPerfectHitTestArea 
         {  
             get { return _pixelPerfectComponent.PixelPerfectHitTestArea; } 
-        }
-
-        public bool IsPixelPerfect
-        {
-            get { return _pixelPerfectComponent.IsPixelPerfect; }
-            set { _pixelPerfectComponent.IsPixelPerfect = value; }
         }
 
         #endregion
@@ -459,6 +466,11 @@ namespace AGS.Engine
 
         #region IBoundingBoxComponent implementation
 
+        public AGSBoundingBox HitTestBoundingBox 
+        {  
+            get { return _boundingBoxComponent.HitTestBoundingBox; } 
+        }
+
         public IBlockingEvent OnBoundingBoxesChanged 
         {  
             get { return _boundingBoxComponent.OnBoundingBoxesChanged; } 
@@ -474,7 +486,19 @@ namespace AGS.Engine
             return _boundingBoxComponent.GetBoundingBoxes(viewport);
         }
 
-        public AGSBoundingBox HitTestBoundingBox { get { return _boundingBoxComponent.HitTestBoundingBox; } }
+        #endregion
+
+        #region IWorldPositionComponent implementation
+
+        public Single WorldX 
+        {  
+            get { return _worldPositionComponent.WorldX; } 
+        }
+
+        public Single WorldY 
+        {  
+            get { return _worldPositionComponent.WorldY; } 
+        }
 
         #endregion
     }

--- a/Source/Engine/AGS.Engine/ComponentsFramework/Templates/AGSObject.generated.cs
+++ b/Source/Engine/AGS.Engine/ComponentsFramework/Templates/AGSObject.generated.cs
@@ -466,9 +466,9 @@ namespace AGS.Engine
 
         #region IBoundingBoxComponent implementation
 
-        public AGSBoundingBox HitTestBoundingBox 
+        public AGSBoundingBox WorldBoundingBox 
         {  
-            get { return _boundingBoxComponent.HitTestBoundingBox; } 
+            get { return _boundingBoxComponent.WorldBoundingBox; } 
         }
 
         public IBlockingEvent OnBoundingBoxesChanged 

--- a/Source/Engine/AGS.Engine/ComponentsFramework/Templates/AGSObject.generated.cs
+++ b/Source/Engine/AGS.Engine/ComponentsFramework/Templates/AGSObject.generated.cs
@@ -474,6 +474,8 @@ namespace AGS.Engine
             return _boundingBoxComponent.GetBoundingBoxes(viewport);
         }
 
+        public AGSBoundingBox HitTestBoundingBox { get { return _boundingBoxComponent.HitTestBoundingBox; } }
+
         #endregion
     }
 }

--- a/Source/Engine/AGS.Engine/ComponentsFramework/Templates/AGSPanel.generated.cs
+++ b/Source/Engine/AGS.Engine/ComponentsFramework/Templates/AGSPanel.generated.cs
@@ -32,45 +32,48 @@ namespace AGS.Engine
         private IPixelPerfectComponent _pixelPerfectComponent;
         private IModelMatrixComponent _modelMatrixComponent;
         private IBoundingBoxComponent _boundingBoxComponent;
+        private IWorldPositionComponent _worldPositionComponent;
 
         public AGSPanel(string id, Resolver resolver, IImage image) : base(id, resolver)
-        {            
+        {
             _uIEvents = AddComponent<IUIEvents>();
-            Bind<IUIEvents>(c => _uIEvents = c, _ => {});            
+            Bind<IUIEvents>(c => _uIEvents = c, _ => {});
             _skinComponent = AddComponent<ISkinComponent>();
-            Bind<ISkinComponent>(c => _skinComponent = c, _ => {});            
+            Bind<ISkinComponent>(c => _skinComponent = c, _ => {});
             _hasRoomComponent = AddComponent<IHasRoomComponent>();
-            Bind<IHasRoomComponent>(c => _hasRoomComponent = c, _ => {});            
+            Bind<IHasRoomComponent>(c => _hasRoomComponent = c, _ => {});
             _animationComponent = AddComponent<IAnimationComponent>();
-            Bind<IAnimationComponent>(c => _animationComponent = c, _ => {});            
+            Bind<IAnimationComponent>(c => _animationComponent = c, _ => {});
             _inObjectTreeComponent = AddComponent<IInObjectTreeComponent>();
-            Bind<IInObjectTreeComponent>(c => _inObjectTreeComponent = c, _ => {});            
+            Bind<IInObjectTreeComponent>(c => _inObjectTreeComponent = c, _ => {});
             _colliderComponent = AddComponent<IColliderComponent>();
-            Bind<IColliderComponent>(c => _colliderComponent = c, _ => {});            
+            Bind<IColliderComponent>(c => _colliderComponent = c, _ => {});
             _visibleComponent = AddComponent<IVisibleComponent>();
-            Bind<IVisibleComponent>(c => _visibleComponent = c, _ => {});            
+            Bind<IVisibleComponent>(c => _visibleComponent = c, _ => {});
             _enabledComponent = AddComponent<IEnabledComponent>();
-            Bind<IEnabledComponent>(c => _enabledComponent = c, _ => {});            
+            Bind<IEnabledComponent>(c => _enabledComponent = c, _ => {});
             _customPropertiesComponent = AddComponent<ICustomPropertiesComponent>();
-            Bind<ICustomPropertiesComponent>(c => _customPropertiesComponent = c, _ => {});            
+            Bind<ICustomPropertiesComponent>(c => _customPropertiesComponent = c, _ => {});
             _drawableInfoComponent = AddComponent<IDrawableInfoComponent>();
-            Bind<IDrawableInfoComponent>(c => _drawableInfoComponent = c, _ => {});            
+            Bind<IDrawableInfoComponent>(c => _drawableInfoComponent = c, _ => {});
             _shaderComponent = AddComponent<IShaderComponent>();
-            Bind<IShaderComponent>(c => _shaderComponent = c, _ => {});            
+            Bind<IShaderComponent>(c => _shaderComponent = c, _ => {});
             _translateComponent = AddComponent<ITranslateComponent>();
-            Bind<ITranslateComponent>(c => _translateComponent = c, _ => {});            
+            Bind<ITranslateComponent>(c => _translateComponent = c, _ => {});
             _imageComponent = AddComponent<IImageComponent>();
-            Bind<IImageComponent>(c => _imageComponent = c, _ => {});            
+            Bind<IImageComponent>(c => _imageComponent = c, _ => {});
             _scaleComponent = AddComponent<IScaleComponent>();
-            Bind<IScaleComponent>(c => _scaleComponent = c, _ => {});            
+            Bind<IScaleComponent>(c => _scaleComponent = c, _ => {});
             _rotateComponent = AddComponent<IRotateComponent>();
-            Bind<IRotateComponent>(c => _rotateComponent = c, _ => {});            
+            Bind<IRotateComponent>(c => _rotateComponent = c, _ => {});
             _pixelPerfectComponent = AddComponent<IPixelPerfectComponent>();
-            Bind<IPixelPerfectComponent>(c => _pixelPerfectComponent = c, _ => {});            
+            Bind<IPixelPerfectComponent>(c => _pixelPerfectComponent = c, _ => {});
             _modelMatrixComponent = AddComponent<IModelMatrixComponent>();
-            Bind<IModelMatrixComponent>(c => _modelMatrixComponent = c, _ => {});            
+            Bind<IModelMatrixComponent>(c => _modelMatrixComponent = c, _ => {});
             _boundingBoxComponent = AddComponent<IBoundingBoxComponent>();
             Bind<IBoundingBoxComponent>(c => _boundingBoxComponent = c, _ => {});
+            _worldPositionComponent = AddComponent<IWorldPositionComponent>();
+            Bind<IWorldPositionComponent>(c => _worldPositionComponent = c, _ => {});
 			beforeInitComponents(resolver, image);
             InitComponents();
             afterInitComponents(resolver, image);
@@ -386,10 +389,10 @@ namespace AGS.Engine
             set { _imageComponent.Tint = value; } 
         }
 
-        public Vector4 Brightness
-        {
-            get { return _imageComponent.Brightness; }
-            set { _imageComponent.Brightness = value; }
+        public Vector4 Brightness 
+        {  
+            get { return _imageComponent.Brightness; }  
+            set { _imageComponent.Brightness = value; } 
         }
 
         public PointF Pivot 
@@ -495,15 +498,19 @@ namespace AGS.Engine
 
         #region IPixelPerfectComponent implementation
 
+        public Boolean IsPixelPerfect 
+        {  
+            get { return _pixelPerfectComponent.IsPixelPerfect; }  
+            set { _pixelPerfectComponent.IsPixelPerfect = value; } 
+        }
+
+        #endregion
+
+        #region IPixelPerfectCollidable implementation
+
         public IArea PixelPerfectHitTestArea 
         {  
             get { return _pixelPerfectComponent.PixelPerfectHitTestArea; } 
-        }
-
-        public bool IsPixelPerfect
-        {
-            get { return _pixelPerfectComponent.IsPixelPerfect; }
-            set { _pixelPerfectComponent.IsPixelPerfect = value; }
         }
 
         #endregion
@@ -529,6 +536,11 @@ namespace AGS.Engine
 
         #region IBoundingBoxComponent implementation
 
+        public AGSBoundingBox HitTestBoundingBox 
+        {  
+            get { return _boundingBoxComponent.HitTestBoundingBox; } 
+        }
+
         public IBlockingEvent OnBoundingBoxesChanged 
         {  
             get { return _boundingBoxComponent.OnBoundingBoxesChanged; } 
@@ -544,7 +556,19 @@ namespace AGS.Engine
             return _boundingBoxComponent.GetBoundingBoxes(viewport);
         }
 
-        public AGSBoundingBox HitTestBoundingBox { get { return _boundingBoxComponent.HitTestBoundingBox; } }
+        #endregion
+
+        #region IWorldPositionComponent implementation
+
+        public Single WorldX 
+        {  
+            get { return _worldPositionComponent.WorldX; } 
+        }
+
+        public Single WorldY 
+        {  
+            get { return _worldPositionComponent.WorldY; } 
+        }
 
         #endregion
     }

--- a/Source/Engine/AGS.Engine/ComponentsFramework/Templates/AGSPanel.generated.cs
+++ b/Source/Engine/AGS.Engine/ComponentsFramework/Templates/AGSPanel.generated.cs
@@ -570,6 +570,11 @@ namespace AGS.Engine
             get { return _worldPositionComponent.WorldY; } 
         }
 
+        public PointF WorldXY
+        {
+            get { return _worldPositionComponent.WorldXY; }
+        }
+
         #endregion
     }
 }

--- a/Source/Engine/AGS.Engine/ComponentsFramework/Templates/AGSPanel.generated.cs
+++ b/Source/Engine/AGS.Engine/ComponentsFramework/Templates/AGSPanel.generated.cs
@@ -544,6 +544,8 @@ namespace AGS.Engine
             return _boundingBoxComponent.GetBoundingBoxes(viewport);
         }
 
+        public AGSBoundingBox HitTestBoundingBox { get { return _boundingBoxComponent.HitTestBoundingBox; } }
+
         #endregion
     }
 }

--- a/Source/Engine/AGS.Engine/ComponentsFramework/Templates/AGSPanel.generated.cs
+++ b/Source/Engine/AGS.Engine/ComponentsFramework/Templates/AGSPanel.generated.cs
@@ -536,9 +536,9 @@ namespace AGS.Engine
 
         #region IBoundingBoxComponent implementation
 
-        public AGSBoundingBox HitTestBoundingBox 
+        public AGSBoundingBox WorldBoundingBox 
         {  
-            get { return _boundingBoxComponent.HitTestBoundingBox; } 
+            get { return _boundingBoxComponent.WorldBoundingBox; } 
         }
 
         public IBlockingEvent OnBoundingBoxesChanged 

--- a/Source/Engine/AGS.Engine/ComponentsFramework/Templates/AGSSlider.generated.cs
+++ b/Source/Engine/AGS.Engine/ComponentsFramework/Templates/AGSSlider.generated.cs
@@ -613,9 +613,9 @@ namespace AGS.Engine
 
         #region IBoundingBoxComponent implementation
 
-        public AGSBoundingBox HitTestBoundingBox 
+        public AGSBoundingBox WorldBoundingBox 
         {  
-            get { return _boundingBoxComponent.HitTestBoundingBox; } 
+            get { return _boundingBoxComponent.WorldBoundingBox; } 
         }
 
         public IBlockingEvent OnBoundingBoxesChanged 

--- a/Source/Engine/AGS.Engine/ComponentsFramework/Templates/AGSSlider.generated.cs
+++ b/Source/Engine/AGS.Engine/ComponentsFramework/Templates/AGSSlider.generated.cs
@@ -621,6 +621,8 @@ namespace AGS.Engine
             return _boundingBoxComponent.GetBoundingBoxes(viewport);
         }
 
+        public AGSBoundingBox HitTestBoundingBox { get { return _boundingBoxComponent.HitTestBoundingBox; } }
+
         #endregion
     }
 }

--- a/Source/Engine/AGS.Engine/ComponentsFramework/Templates/AGSSlider.generated.cs
+++ b/Source/Engine/AGS.Engine/ComponentsFramework/Templates/AGSSlider.generated.cs
@@ -647,6 +647,11 @@ namespace AGS.Engine
             get { return _worldPositionComponent.WorldY; } 
         }
 
+        public PointF WorldXY
+        {
+            get { return _worldPositionComponent.WorldXY; }
+        }
+
         #endregion
     }
 }

--- a/Source/Engine/AGS.Engine/ComponentsFramework/Templates/AGSSlider.generated.cs
+++ b/Source/Engine/AGS.Engine/ComponentsFramework/Templates/AGSSlider.generated.cs
@@ -33,47 +33,50 @@ namespace AGS.Engine
         private IPixelPerfectComponent _pixelPerfectComponent;
         private IModelMatrixComponent _modelMatrixComponent;
         private IBoundingBoxComponent _boundingBoxComponent;
+        private IWorldPositionComponent _worldPositionComponent;
 
         public AGSSlider(string id, Resolver resolver, IImage image) : base(id, resolver)
-        {            
+        {
             _sliderComponent = AddComponent<ISliderComponent>();
-            Bind<ISliderComponent>(c => _sliderComponent = c, _ => {});            
+            Bind<ISliderComponent>(c => _sliderComponent = c, _ => {});
             _uIEvents = AddComponent<IUIEvents>();
-            Bind<IUIEvents>(c => _uIEvents = c, _ => {});            
+            Bind<IUIEvents>(c => _uIEvents = c, _ => {});
             _skinComponent = AddComponent<ISkinComponent>();
-            Bind<ISkinComponent>(c => _skinComponent = c, _ => {});            
+            Bind<ISkinComponent>(c => _skinComponent = c, _ => {});
             _hasRoomComponent = AddComponent<IHasRoomComponent>();
-            Bind<IHasRoomComponent>(c => _hasRoomComponent = c, _ => {});            
+            Bind<IHasRoomComponent>(c => _hasRoomComponent = c, _ => {});
             _animationComponent = AddComponent<IAnimationComponent>();
-            Bind<IAnimationComponent>(c => _animationComponent = c, _ => {});            
+            Bind<IAnimationComponent>(c => _animationComponent = c, _ => {});
             _inObjectTreeComponent = AddComponent<IInObjectTreeComponent>();
-            Bind<IInObjectTreeComponent>(c => _inObjectTreeComponent = c, _ => {});            
+            Bind<IInObjectTreeComponent>(c => _inObjectTreeComponent = c, _ => {});
             _colliderComponent = AddComponent<IColliderComponent>();
-            Bind<IColliderComponent>(c => _colliderComponent = c, _ => {});            
+            Bind<IColliderComponent>(c => _colliderComponent = c, _ => {});
             _visibleComponent = AddComponent<IVisibleComponent>();
-            Bind<IVisibleComponent>(c => _visibleComponent = c, _ => {});            
+            Bind<IVisibleComponent>(c => _visibleComponent = c, _ => {});
             _enabledComponent = AddComponent<IEnabledComponent>();
-            Bind<IEnabledComponent>(c => _enabledComponent = c, _ => {});            
+            Bind<IEnabledComponent>(c => _enabledComponent = c, _ => {});
             _customPropertiesComponent = AddComponent<ICustomPropertiesComponent>();
-            Bind<ICustomPropertiesComponent>(c => _customPropertiesComponent = c, _ => {});            
+            Bind<ICustomPropertiesComponent>(c => _customPropertiesComponent = c, _ => {});
             _drawableInfoComponent = AddComponent<IDrawableInfoComponent>();
-            Bind<IDrawableInfoComponent>(c => _drawableInfoComponent = c, _ => {});            
+            Bind<IDrawableInfoComponent>(c => _drawableInfoComponent = c, _ => {});
             _shaderComponent = AddComponent<IShaderComponent>();
-            Bind<IShaderComponent>(c => _shaderComponent = c, _ => {});            
+            Bind<IShaderComponent>(c => _shaderComponent = c, _ => {});
             _translateComponent = AddComponent<ITranslateComponent>();
-            Bind<ITranslateComponent>(c => _translateComponent = c, _ => {});            
+            Bind<ITranslateComponent>(c => _translateComponent = c, _ => {});
             _imageComponent = AddComponent<IImageComponent>();
-            Bind<IImageComponent>(c => _imageComponent = c, _ => {});            
+            Bind<IImageComponent>(c => _imageComponent = c, _ => {});
             _scaleComponent = AddComponent<IScaleComponent>();
-            Bind<IScaleComponent>(c => _scaleComponent = c, _ => {});            
+            Bind<IScaleComponent>(c => _scaleComponent = c, _ => {});
             _rotateComponent = AddComponent<IRotateComponent>();
-            Bind<IRotateComponent>(c => _rotateComponent = c, _ => {});            
+            Bind<IRotateComponent>(c => _rotateComponent = c, _ => {});
             _pixelPerfectComponent = AddComponent<IPixelPerfectComponent>();
-            Bind<IPixelPerfectComponent>(c => _pixelPerfectComponent = c, _ => {});            
+            Bind<IPixelPerfectComponent>(c => _pixelPerfectComponent = c, _ => {});
             _modelMatrixComponent = AddComponent<IModelMatrixComponent>();
-            Bind<IModelMatrixComponent>(c => _modelMatrixComponent = c, _ => {});            
+            Bind<IModelMatrixComponent>(c => _modelMatrixComponent = c, _ => {});
             _boundingBoxComponent = AddComponent<IBoundingBoxComponent>();
             Bind<IBoundingBoxComponent>(c => _boundingBoxComponent = c, _ => {});
+            _worldPositionComponent = AddComponent<IWorldPositionComponent>();
+            Bind<IWorldPositionComponent>(c => _worldPositionComponent = c, _ => {});
 			beforeInitComponents(resolver, image);
             InitComponents();
             afterInitComponents(resolver, image);
@@ -463,10 +466,10 @@ namespace AGS.Engine
             set { _imageComponent.Tint = value; } 
         }
 
-        public Vector4 Brightness
-        {
-            get { return _imageComponent.Brightness; }
-            set { _imageComponent.Brightness = value; }
+        public Vector4 Brightness 
+        {  
+            get { return _imageComponent.Brightness; }  
+            set { _imageComponent.Brightness = value; } 
         }
 
         public PointF Pivot 
@@ -572,15 +575,19 @@ namespace AGS.Engine
 
         #region IPixelPerfectComponent implementation
 
+        public Boolean IsPixelPerfect 
+        {  
+            get { return _pixelPerfectComponent.IsPixelPerfect; }  
+            set { _pixelPerfectComponent.IsPixelPerfect = value; } 
+        }
+
+        #endregion
+
+        #region IPixelPerfectCollidable implementation
+
         public IArea PixelPerfectHitTestArea 
         {  
             get { return _pixelPerfectComponent.PixelPerfectHitTestArea; } 
-        }
-
-        public bool IsPixelPerfect
-        {
-            get { return _pixelPerfectComponent.IsPixelPerfect; }
-            set { _pixelPerfectComponent.IsPixelPerfect = value; }
         }
 
         #endregion
@@ -606,6 +613,11 @@ namespace AGS.Engine
 
         #region IBoundingBoxComponent implementation
 
+        public AGSBoundingBox HitTestBoundingBox 
+        {  
+            get { return _boundingBoxComponent.HitTestBoundingBox; } 
+        }
+
         public IBlockingEvent OnBoundingBoxesChanged 
         {  
             get { return _boundingBoxComponent.OnBoundingBoxesChanged; } 
@@ -621,7 +633,19 @@ namespace AGS.Engine
             return _boundingBoxComponent.GetBoundingBoxes(viewport);
         }
 
-        public AGSBoundingBox HitTestBoundingBox { get { return _boundingBoxComponent.HitTestBoundingBox; } }
+        #endregion
+
+        #region IWorldPositionComponent implementation
+
+        public Single WorldX 
+        {  
+            get { return _worldPositionComponent.WorldX; } 
+        }
+
+        public Single WorldY 
+        {  
+            get { return _worldPositionComponent.WorldY; } 
+        }
 
         #endregion
     }

--- a/Source/Engine/AGS.Engine/ComponentsFramework/Templates/AGSTextbox.generated.cs
+++ b/Source/Engine/AGS.Engine/ComponentsFramework/Templates/AGSTextbox.generated.cs
@@ -576,6 +576,11 @@ namespace AGS.Engine
             get { return _worldPositionComponent.WorldY; } 
         }
 
+        public PointF WorldXY
+        {
+            get { return _worldPositionComponent.WorldXY; }
+        }
+
         #endregion
 
         #region ITextComponent implementation

--- a/Source/Engine/AGS.Engine/ComponentsFramework/Templates/AGSTextbox.generated.cs
+++ b/Source/Engine/AGS.Engine/ComponentsFramework/Templates/AGSTextbox.generated.cs
@@ -550,6 +550,8 @@ namespace AGS.Engine
             return _boundingBoxComponent.GetBoundingBoxes(viewport);
         }
 
+        public AGSBoundingBox HitTestBoundingBox { get { return _boundingBoxComponent.HitTestBoundingBox; } }
+
         #endregion
 
         #region ITextComponent implementation

--- a/Source/Engine/AGS.Engine/ComponentsFramework/Templates/AGSTextbox.generated.cs
+++ b/Source/Engine/AGS.Engine/ComponentsFramework/Templates/AGSTextbox.generated.cs
@@ -32,49 +32,52 @@ namespace AGS.Engine
         private IPixelPerfectComponent _pixelPerfectComponent;
         private IModelMatrixComponent _modelMatrixComponent;
         private IBoundingBoxComponent _boundingBoxComponent;
+        private IWorldPositionComponent _worldPositionComponent;
         private ITextComponent _textComponent;
         private ITextBoxComponent _textBoxComponent;
 
         public AGSTextbox(string id, Resolver resolver) : base(id, resolver)
-        {            
+        {
             _uIEvents = AddComponent<IUIEvents>();
-            Bind<IUIEvents>(c => _uIEvents = c, _ => {});            
+            Bind<IUIEvents>(c => _uIEvents = c, _ => {});
             _skinComponent = AddComponent<ISkinComponent>();
-            Bind<ISkinComponent>(c => _skinComponent = c, _ => {});            
+            Bind<ISkinComponent>(c => _skinComponent = c, _ => {});
             _hasRoomComponent = AddComponent<IHasRoomComponent>();
-            Bind<IHasRoomComponent>(c => _hasRoomComponent = c, _ => {});            
+            Bind<IHasRoomComponent>(c => _hasRoomComponent = c, _ => {});
             _animationComponent = AddComponent<IAnimationComponent>();
-            Bind<IAnimationComponent>(c => _animationComponent = c, _ => {});            
+            Bind<IAnimationComponent>(c => _animationComponent = c, _ => {});
             _inObjectTreeComponent = AddComponent<IInObjectTreeComponent>();
-            Bind<IInObjectTreeComponent>(c => _inObjectTreeComponent = c, _ => {});            
+            Bind<IInObjectTreeComponent>(c => _inObjectTreeComponent = c, _ => {});
             _colliderComponent = AddComponent<IColliderComponent>();
-            Bind<IColliderComponent>(c => _colliderComponent = c, _ => {});            
+            Bind<IColliderComponent>(c => _colliderComponent = c, _ => {});
             _visibleComponent = AddComponent<IVisibleComponent>();
-            Bind<IVisibleComponent>(c => _visibleComponent = c, _ => {});            
+            Bind<IVisibleComponent>(c => _visibleComponent = c, _ => {});
             _enabledComponent = AddComponent<IEnabledComponent>();
-            Bind<IEnabledComponent>(c => _enabledComponent = c, _ => {});            
+            Bind<IEnabledComponent>(c => _enabledComponent = c, _ => {});
             _customPropertiesComponent = AddComponent<ICustomPropertiesComponent>();
-            Bind<ICustomPropertiesComponent>(c => _customPropertiesComponent = c, _ => {});            
+            Bind<ICustomPropertiesComponent>(c => _customPropertiesComponent = c, _ => {});
             _drawableInfoComponent = AddComponent<IDrawableInfoComponent>();
-            Bind<IDrawableInfoComponent>(c => _drawableInfoComponent = c, _ => {});            
+            Bind<IDrawableInfoComponent>(c => _drawableInfoComponent = c, _ => {});
             _shaderComponent = AddComponent<IShaderComponent>();
-            Bind<IShaderComponent>(c => _shaderComponent = c, _ => {});            
+            Bind<IShaderComponent>(c => _shaderComponent = c, _ => {});
             _translateComponent = AddComponent<ITranslateComponent>();
-            Bind<ITranslateComponent>(c => _translateComponent = c, _ => {});            
+            Bind<ITranslateComponent>(c => _translateComponent = c, _ => {});
             _imageComponent = AddComponent<IImageComponent>();
-            Bind<IImageComponent>(c => _imageComponent = c, _ => {});            
+            Bind<IImageComponent>(c => _imageComponent = c, _ => {});
             _scaleComponent = AddComponent<IScaleComponent>();
-            Bind<IScaleComponent>(c => _scaleComponent = c, _ => {});            
+            Bind<IScaleComponent>(c => _scaleComponent = c, _ => {});
             _rotateComponent = AddComponent<IRotateComponent>();
-            Bind<IRotateComponent>(c => _rotateComponent = c, _ => {});            
+            Bind<IRotateComponent>(c => _rotateComponent = c, _ => {});
             _pixelPerfectComponent = AddComponent<IPixelPerfectComponent>();
-            Bind<IPixelPerfectComponent>(c => _pixelPerfectComponent = c, _ => {});            
+            Bind<IPixelPerfectComponent>(c => _pixelPerfectComponent = c, _ => {});
             _modelMatrixComponent = AddComponent<IModelMatrixComponent>();
-            Bind<IModelMatrixComponent>(c => _modelMatrixComponent = c, _ => {});            
+            Bind<IModelMatrixComponent>(c => _modelMatrixComponent = c, _ => {});
             _boundingBoxComponent = AddComponent<IBoundingBoxComponent>();
-            Bind<IBoundingBoxComponent>(c => _boundingBoxComponent = c, _ => {});            
+            Bind<IBoundingBoxComponent>(c => _boundingBoxComponent = c, _ => {});
+            _worldPositionComponent = AddComponent<IWorldPositionComponent>();
+            Bind<IWorldPositionComponent>(c => _worldPositionComponent = c, _ => {});
             _textComponent = AddComponent<ITextComponent>();
-            Bind<ITextComponent>(c => _textComponent = c, _ => {});            
+            Bind<ITextComponent>(c => _textComponent = c, _ => {});
             _textBoxComponent = AddComponent<ITextBoxComponent>();
             Bind<ITextBoxComponent>(c => _textBoxComponent = c, _ => {});
 			beforeInitComponents(resolver);
@@ -392,10 +395,10 @@ namespace AGS.Engine
             set { _imageComponent.Tint = value; } 
         }
 
-        public Vector4 Brightness
-        {
-            get { return _imageComponent.Brightness; }
-            set { _imageComponent.Brightness = value; }
+        public Vector4 Brightness 
+        {  
+            get { return _imageComponent.Brightness; }  
+            set { _imageComponent.Brightness = value; } 
         }
 
         public PointF Pivot 
@@ -501,15 +504,19 @@ namespace AGS.Engine
 
         #region IPixelPerfectComponent implementation
 
+        public Boolean IsPixelPerfect 
+        {  
+            get { return _pixelPerfectComponent.IsPixelPerfect; }  
+            set { _pixelPerfectComponent.IsPixelPerfect = value; } 
+        }
+
+        #endregion
+
+        #region IPixelPerfectCollidable implementation
+
         public IArea PixelPerfectHitTestArea 
         {  
             get { return _pixelPerfectComponent.PixelPerfectHitTestArea; } 
-        }
-
-        public bool IsPixelPerfect
-        {
-            get { return _pixelPerfectComponent.IsPixelPerfect; }
-            set { _pixelPerfectComponent.IsPixelPerfect = value; }
         }
 
         #endregion
@@ -535,6 +542,11 @@ namespace AGS.Engine
 
         #region IBoundingBoxComponent implementation
 
+        public AGSBoundingBox HitTestBoundingBox 
+        {  
+            get { return _boundingBoxComponent.HitTestBoundingBox; } 
+        }
+
         public IBlockingEvent OnBoundingBoxesChanged 
         {  
             get { return _boundingBoxComponent.OnBoundingBoxesChanged; } 
@@ -550,7 +562,19 @@ namespace AGS.Engine
             return _boundingBoxComponent.GetBoundingBoxes(viewport);
         }
 
-        public AGSBoundingBox HitTestBoundingBox { get { return _boundingBoxComponent.HitTestBoundingBox; } }
+        #endregion
+
+        #region IWorldPositionComponent implementation
+
+        public Single WorldX 
+        {  
+            get { return _worldPositionComponent.WorldX; } 
+        }
+
+        public Single WorldY 
+        {  
+            get { return _worldPositionComponent.WorldY; } 
+        }
 
         #endregion
 

--- a/Source/Engine/AGS.Engine/ComponentsFramework/Templates/AGSTextbox.generated.cs
+++ b/Source/Engine/AGS.Engine/ComponentsFramework/Templates/AGSTextbox.generated.cs
@@ -542,9 +542,9 @@ namespace AGS.Engine
 
         #region IBoundingBoxComponent implementation
 
-        public AGSBoundingBox HitTestBoundingBox 
+        public AGSBoundingBox WorldBoundingBox 
         {  
-            get { return _boundingBoxComponent.HitTestBoundingBox; } 
+            get { return _boundingBoxComponent.WorldBoundingBox; } 
         }
 
         public IBlockingEvent OnBoundingBoxesChanged 

--- a/Source/Engine/AGS.Engine/ComponentsFramework/Templates/EntityCreatorTemplate.tt
+++ b/Source/Engine/AGS.Engine/ComponentsFramework/Templates/EntityCreatorTemplate.tt
@@ -100,7 +100,7 @@ namespace <#= NamespaceName #>
         {
             if (!
             WriteInitComponent(component)) continue;#>
-            
+
             <#= getVarName(component) #> = AddComponent<<#= helper.GetTypeName(component) #>>();
             Bind<<#= helper.GetTypeName(component) #>>(c => <#= getVarName(component) #> = c, _ => {});<#+
             }

--- a/Source/Engine/AGS.Engine/Game/Factories/AGSUIFactory.cs
+++ b/Source/Engine/AGS.Engine/Game/Factories/AGSUIFactory.cs
@@ -406,7 +406,7 @@ namespace AGS.Engine
 
             Action placePanel = () =>
             {
-                var box = textBox.GetBoundingBoxes(_gameState.Viewport)?.RenderBox;
+                var box = textBox.GetBoundingBoxes(_gameState.Viewport)?.ViewportBox;
                 if (box == null) return;
                 dropDownPanel.Location = new AGSLocation(box.Value.BottomLeft.X, box.Value.BottomLeft.Y);
             };

--- a/Source/Engine/AGS.Engine/Graphics/Logic/AGSMatrixUpdater.cs
+++ b/Source/Engine/AGS.Engine/Graphics/Logic/AGSMatrixUpdater.cs
@@ -8,9 +8,11 @@ namespace AGS.Engine
     {
         private readonly Stack<IObject> _parentStack;
         private readonly HashSet<string> _alreadyRefreshedIdsCache;
+        private readonly IGameState _state;
 
-        public AGSMatrixUpdater()
+        public AGSMatrixUpdater(IGameState state)
         {
+            _state = state;
             _parentStack = new Stack<IObject>();
             _alreadyRefreshedIdsCache = new HashSet<string>();
         }
@@ -36,6 +38,7 @@ namespace AGS.Engine
                 parent = _parentStack.Pop();
                 _alreadyRefreshedIdsCache.Add(parent.ID);
                 parent.GetModelMatrices();
+                parent.GetBoundingBoxes(_state.Viewport);
             }
         }
     }

--- a/Source/Engine/AGS.Engine/Graphics/Logic/GLImageRenderer.cs
+++ b/Source/Engine/AGS.Engine/Graphics/Logic/GLImageRenderer.cs
@@ -40,7 +40,7 @@ namespace AGS.Engine
                 return;
             }
             var boundingBoxes = obj.GetBoundingBoxes(viewport);
-            if (boundingBoxes == null || !boundingBoxes.RenderBox.IsValid)
+            if (boundingBoxes == null || !boundingBoxes.ViewportBox.IsValid)
             {
                 return;
             }
@@ -56,8 +56,8 @@ namespace AGS.Engine
             if (!obj.Visible) return;
 			if (border != null)
 			{
-                if (boundingBoxes.RenderBox.BottomLeft.X > boundingBoxes.RenderBox.BottomRight.X) borderBox = boundingBoxes.RenderBox.FlipHorizontal();
-                else borderBox = boundingBoxes.RenderBox;
+                if (boundingBoxes.ViewportBox.BottomLeft.X > boundingBoxes.ViewportBox.BottomRight.X) borderBox = boundingBoxes.ViewportBox.FlipHorizontal();
+                else borderBox = boundingBoxes.ViewportBox;
 
 				border.RenderBorderBack(borderBox);
 			}

--- a/Source/Engine/AGS.Engine/Graphics/Logic/GLTextureRenderer.cs
+++ b/Source/Engine/AGS.Engine/Graphics/Logic/GLTextureRenderer.cs
@@ -17,11 +17,11 @@ namespace AGS.Engine
 		{
             if (boundingBoxes.TextureBox == null)
             {
-                _glUtils.DrawQuad(texture, boundingBoxes.RenderBox, color.R, color.G, color.B, color.A);
+                _glUtils.DrawQuad(texture, boundingBoxes.ViewportBox, color.R, color.G, color.B, color.A);
             }
             else
             {
-                _glUtils.DrawQuad(texture, boundingBoxes.RenderBox, color, boundingBoxes.TextureBox);
+                _glUtils.DrawQuad(texture, boundingBoxes.ViewportBox, color, boundingBoxes.TextureBox);
             }
 		}
 

--- a/Source/Engine/AGS.Engine/Graphics/Logic/Utils/GLUtils.cs
+++ b/Source/Engine/AGS.Engine/Graphics/Logic/Utils/GLUtils.cs
@@ -84,8 +84,8 @@ namespace AGS.Engine
                 var boundingBoxes = parent.GetBoundingBoxes(_state.Viewport);
 				if (boundingBoxes != null)
 				{
-                    viewX += boundingBoxes.RenderBox.MinX;
-                    viewY += boundingBoxes.RenderBox.MinY;
+                    viewX += boundingBoxes.ViewportBox.MinX;
+                    viewY += boundingBoxes.ViewportBox.MinY;
 				}
 			}
 			width = (int)Math.Round((float)width * projectionBox.Width);

--- a/Source/Engine/AGS.Engine/Input/Schemes/KeyboardMovement.cs
+++ b/Source/Engine/AGS.Engine/Input/Schemes/KeyboardMovement.cs
@@ -149,8 +149,8 @@ namespace AGS.Engine
 
 		private ILocation findFarWalkable(float xOffset, float yOffset)
 		{
-			float x = _character.X;
-			float y = _character.Y;
+            float x = _character.WorldX;
+            float y = _character.WorldY;
 			bool walkable = true;
 			while (walkable)
 			{

--- a/Source/Engine/AGS.Engine/Objects/AGSBoundingBoxWithChildrenComponent.cs
+++ b/Source/Engine/AGS.Engine/Objects/AGSBoundingBoxWithChildrenComponent.cs
@@ -144,8 +144,8 @@ namespace AGS.Engine
             var lastBox = BoundingBoxWithChildren;
             var lastPreBox = PreCropBoundingBoxWithChildren;
             _isDirty = false;
-            _boundingBoxWithChildren = getBoundingBox(_tree, _boundingBox, boxes => boxes.RenderBox, DebugPrintouts ? $"Box ({_entity.ID})" : null);
-            _preCropBoundingBoxWithChildren = getBoundingBox(_tree, _boundingBox, boxes => boxes.PreCropRenderBox, DebugPrintouts ? $"Box Pre Crop ({_entity.ID})" : null);
+            _boundingBoxWithChildren = getBoundingBox(_tree, _boundingBox, boxes => boxes.ViewportBox, DebugPrintouts ? $"Box ({_entity.ID})" : null);
+            _preCropBoundingBoxWithChildren = getBoundingBox(_tree, _boundingBox, boxes => boxes.PreCropViewportBox, DebugPrintouts ? $"Box Pre Crop ({_entity.ID})" : null);
             if (DebugPrintouts)
             {
                 Debug.WriteLine($"Pre crop for {_entity.ID}: {_preCropBoundingBoxWithChildren.ToString()}");
@@ -157,8 +157,8 @@ namespace AGS.Engine
         {
             var lastBox = BoundingBoxWithChildren;
             var lastPreBox = PreCropBoundingBoxWithChildren;
-            _preUnlockBoundingBox = getBoundingBox(_tree, _boundingBox, boxes => boxes.RenderBox, DebugPrintouts ? $"Box before unlock ({_entity.ID})" : null);
-            _preUnlockPreCropBoundingBox = getBoundingBox(_tree, _boundingBox, boxes => boxes.PreCropRenderBox, DebugPrintouts ? $"Box Pre Crop before unlock ({_entity.ID})" : null);
+            _preUnlockBoundingBox = getBoundingBox(_tree, _boundingBox, boxes => boxes.ViewportBox, DebugPrintouts ? $"Box before unlock ({_entity.ID})" : null);
+            _preUnlockPreCropBoundingBox = getBoundingBox(_tree, _boundingBox, boxes => boxes.PreCropViewportBox, DebugPrintouts ? $"Box Pre Crop before unlock ({_entity.ID})" : null);
             if (DebugPrintouts)
             {
                 Debug.WriteLine($"Pre crop (before unlock) for ${_entity.ID}: {_preUnlockBoundingBox.ToString()}");

--- a/Source/Engine/AGS.Engine/Objects/Characters/Talking/AGSSayComponent.cs
+++ b/Source/Engine/AGS.Engine/Objects/Characters/Talking/AGSSayComponent.cs
@@ -40,7 +40,7 @@ namespace AGS.Engine
         {
             base.Init(entity);
             _characterName = entity.ID;
-            entity.Bind<ITranslateComponent>(c => _emitter.Translate = c, _ => _emitter.Translate = null);
+            entity.Bind<IWorldPositionComponent>(c => _emitter.WorldPosition = c, _ => _emitter.WorldPosition = null);
             entity.Bind<IHasRoomComponent>(c => _emitter.HasRoom = c, _ => _emitter.HasRoom = null);
             entity.Bind<IFaceDirectionComponent>(c => _faceDirection = c, _ => _faceDirection = null);
             entity.Bind<IOutfitComponent>(c => _outfit = c, _ => _outfit = null);

--- a/Source/Engine/AGS.Engine/Objects/Characters/Talking/AGSSayLocationProvider.cs
+++ b/Source/Engine/AGS.Engine/Objects/Characters/Talking/AGSSayLocationProvider.cs
@@ -28,11 +28,11 @@ namespace AGS.Engine
 		{
             var portraitLocation = getPortraitLocation(config);
             _lastSpeaker = _obj;
-            var boundingBoxes = _obj.GetBoundingBoxes(_state.Viewport);
-            float x = portraitLocation == null ? (boundingBoxes.HitTestBox.MaxX - (_obj.IgnoreViewport ? 0 : _state.Viewport.X)) 
+            var boundingBox = _obj.HitTestBoundingBox;
+            float x = portraitLocation == null ? (boundingBox.MaxX - (_obj.IgnoreViewport ? 0 : _state.Viewport.X)) 
                                                   : portraitLocation.Value.X;
             if (portraitLocation != null && _lastSpeakerOnLeft) x += config.PortraitConfig.Portrait.Width + getBorderWidth(config.PortraitConfig, true).X;
-            float y = portraitLocation == null ? (boundingBoxes.HitTestBox.MaxY - (_obj.IgnoreViewport ? 0 : _state.Viewport.Y)) 
+            float y = portraitLocation == null ? (boundingBox.MaxY - (_obj.IgnoreViewport ? 0 : _state.Viewport.Y)) 
                                                   : _settings.VirtualResolution.Height;
             return new AGSSayLocation(getTextLocation(text, config, x, y), portraitLocation);
 		}

--- a/Source/Engine/AGS.Engine/Objects/Characters/Talking/AGSSayLocationProvider.cs
+++ b/Source/Engine/AGS.Engine/Objects/Characters/Talking/AGSSayLocationProvider.cs
@@ -28,7 +28,7 @@ namespace AGS.Engine
 		{
             var portraitLocation = getPortraitLocation(config);
             _lastSpeaker = _obj;
-            var boundingBox = _obj.HitTestBoundingBox;
+            var boundingBox = _obj.WorldBoundingBox;
             float x = portraitLocation == null ? (boundingBox.MaxX - (_obj.IgnoreViewport ? 0 : _state.Viewport.X)) 
                                                   : portraitLocation.Value.X;
             if (portraitLocation != null && _lastSpeakerOnLeft) x += config.PortraitConfig.Portrait.Width + getBorderWidth(config.PortraitConfig, true).X;

--- a/Source/Engine/AGS.Engine/Objects/Collisions/AGSBoundingBoxComponent.cs
+++ b/Source/Engine/AGS.Engine/Objects/Collisions/AGSBoundingBoxComponent.cs
@@ -48,7 +48,7 @@ namespace AGS.Engine
         [Property(Browsable = false)]
         public ILockStep BoundingBoxLockStep => this;
 
-        public AGSBoundingBox HitTestBoundingBox => _pendingLocks > 0 ? GetBoundingBoxes(_state.Viewport).HitTestBox : _hitTestBox; 
+        public AGSBoundingBox WorldBoundingBox => _pendingLocks > 0 ? GetBoundingBoxes(_state.Viewport).WorldBox : _hitTestBox; 
 
         public override void Init(IEntity entity)
         {
@@ -75,9 +75,9 @@ namespace AGS.Engine
             {
                 boxes.PreLockBoundingBoxes = new AGSBoundingBoxes
                 {
-                    HitTestBox = boxes.BoundingBoxes.HitTestBox,
-                    PreCropRenderBox = boxes.BoundingBoxes.PreCropRenderBox,
-                    RenderBox = boxes.BoundingBoxes.RenderBox,
+                    WorldBox = boxes.BoundingBoxes.WorldBox,
+                    PreCropViewportBox = boxes.BoundingBoxes.PreCropViewportBox,
+                    ViewportBox = boxes.BoundingBoxes.ViewportBox,
                     TextureBox = boxes.BoundingBoxes.TextureBox
                 };
             }
@@ -194,9 +194,9 @@ namespace AGS.Engine
             }
 
             var cropInfo = renderBox.Crop(BoundingBoxType.Render, crop, renderCropScale);
-			boundingBoxes.PreCropRenderBox = renderBox;
+			boundingBoxes.PreCropViewportBox = renderBox;
 			renderBox = cropInfo.BoundingBox;
-            boundingBoxes.RenderBox = renderBox;
+            boundingBoxes.ViewportBox = renderBox;
             if (cropInfo.TextureBox != null)
             {
                 boundingBoxes.TextureBox = cropInfo.TextureBox;
@@ -216,12 +216,12 @@ namespace AGS.Engine
 
             if (cropInfo.Equals(_defaultCropInfo))
             {
-                boundingBoxes.HitTestBox = default;
+                boundingBoxes.WorldBox = default;
             }
             else
             {
                 hitTestBox = hitTestBox.Crop(BoundingBoxType.HitTest, crop, hitTestCropScale).BoundingBox;
-                boundingBoxes.HitTestBox = hitTestBox;
+                boundingBoxes.WorldBox = hitTestBox;
             }
 
             return boundingBoxes;

--- a/Source/Engine/AGS.Engine/Objects/Collisions/AGSBoundingBoxComponent.cs
+++ b/Source/Engine/AGS.Engine/Objects/Collisions/AGSBoundingBoxComponent.cs
@@ -48,6 +48,8 @@ namespace AGS.Engine
         [Property(Browsable = false)]
         public ILockStep BoundingBoxLockStep => this;
 
+        public AGSBoundingBox HitTestBoundingBox => _pendingLocks > 0 ? GetBoundingBoxes(_state.Viewport).HitTestBox : _hitTestBox; 
+
         public override void Init(IEntity entity)
         {
             _entity = entity;

--- a/Source/Engine/AGS.Engine/Objects/Collisions/AGSCollider.cs
+++ b/Source/Engine/AGS.Engine/Objects/Collisions/AGSCollider.cs
@@ -36,7 +36,7 @@ namespace AGS.Engine
 			{
                 var boundingBoxesComponent = _boundingBox;
                 if (boundingBoxesComponent == null) return null;
-                var boundingBox = boundingBoxesComponent.HitTestBoundingBox;
+                var boundingBox = boundingBoxesComponent.WorldBoundingBox;
                 var pixelPerfectComponent = _pixelPerfect;
                 var pixelPerfect = pixelPerfectComponent == null ? null : pixelPerfectComponent.PixelPerfectHitTestArea;
 				float minX = boundingBox.MinX;
@@ -54,7 +54,7 @@ namespace AGS.Engine
 		{
 			var boundingBoxesComponent = _boundingBox;
             if (boundingBoxesComponent == null) return false;
-            AGSBoundingBox boundingBox = boundingBoxesComponent.HitTestBoundingBox;
+            AGSBoundingBox boundingBox = boundingBoxesComponent.WorldBoundingBox;
             var pixelPerfectComponent = _pixelPerfect;
             IArea pixelPerfect = pixelPerfectComponent == null || !pixelPerfectComponent.IsPixelPerfect ? null : pixelPerfectComponent.PixelPerfectHitTestArea;
 

--- a/Source/Engine/AGS.Engine/Objects/Collisions/AGSCollider.cs
+++ b/Source/Engine/AGS.Engine/Objects/Collisions/AGSCollider.cs
@@ -36,9 +36,7 @@ namespace AGS.Engine
 			{
                 var boundingBoxesComponent = _boundingBox;
                 if (boundingBoxesComponent == null) return null;
-                var boundingBoxes = boundingBoxesComponent.GetBoundingBoxes(_state.Viewport);
-                if (boundingBoxes == null) return null;
-                var boundingBox = boundingBoxes.HitTestBox;
+                var boundingBox = boundingBoxesComponent.HitTestBoundingBox;
                 var pixelPerfectComponent = _pixelPerfect;
                 var pixelPerfect = pixelPerfectComponent == null ? null : pixelPerfectComponent.PixelPerfectHitTestArea;
 				float minX = boundingBox.MinX;
@@ -56,9 +54,7 @@ namespace AGS.Engine
 		{
 			var boundingBoxesComponent = _boundingBox;
             if (boundingBoxesComponent == null) return false;
-            var boundingBoxes = boundingBoxesComponent.GetBoundingBoxes(viewport);
-            if (boundingBoxes == null) return false;
-            AGSBoundingBox boundingBox = boundingBoxes.HitTestBox;
+            AGSBoundingBox boundingBox = boundingBoxesComponent.HitTestBoundingBox;
             var pixelPerfectComponent = _pixelPerfect;
             IArea pixelPerfect = pixelPerfectComponent == null || !pixelPerfectComponent.IsPixelPerfect ? null : pixelPerfectComponent.PixelPerfectHitTestArea;
 

--- a/Source/Engine/AGS.Engine/Objects/Transform/AGSWorldPositionComponent.cs
+++ b/Source/Engine/AGS.Engine/Objects/Transform/AGSWorldPositionComponent.cs
@@ -8,7 +8,7 @@ namespace AGS.Engine
     [RequiredComponent(typeof(IImageComponent))]
     public class AGSWorldPositionComponent : AGSComponent, IWorldPositionComponent
     {
-        private float _worldX, _worldY;
+        private PointF _worldXY;
         private IBoundingBoxComponent _box;
         private IImageComponent _image;
 
@@ -26,15 +26,20 @@ namespace AGS.Engine
         [DoNotNotify]
 		public float WorldX 
         { 
-            get => _worldX;
+            get => _worldXY.X;
             //todo: set
         }
 
         [DoNotNotify]
         public float WorldY 
         { 
-            get => _worldY;
+            get => _worldXY.Y;
             //todo: set
+        }
+
+        public PointF WorldXY
+        {
+            get => _worldXY;
         }
 
         private void refresh()
@@ -44,18 +49,22 @@ namespace AGS.Engine
             if (boxComponent == null || image == null) return;
             var box = _box.HitTestBoundingBox;
             var pivot = _image.Pivot;
-            var oldX = _worldX;
-            var oldY = _worldY;
-            _worldX = MathUtils.Lerp(0f, box.MinX, 1f, box.MaxX, pivot.X);
-            _worldY = MathUtils.Lerp(0f, box.MinY, 1f, box.MaxY, pivot.Y);
-            if (!MathUtils.FloatEquals(oldX, _worldX))
+            var oldXY = _worldXY;
+            var worldX = MathUtils.Lerp(0f, box.MinX, 1f, box.MaxX, pivot.X);
+            var worldY = MathUtils.Lerp(0f, box.MinY, 1f, box.MaxY, pivot.Y);
+            _worldXY = new PointF(worldX, worldY);
+            bool changed = false;
+            if (!MathUtils.FloatEquals(oldXY.X, worldX))
             {
                 OnPropertyChanged(nameof(WorldX));
+                changed = true;
             }
-            if (!MathUtils.FloatEquals(oldY, _worldY))
+            if (!MathUtils.FloatEquals(oldXY.Y, worldY))
             {
                 OnPropertyChanged(nameof(WorldY));
+                changed = true;
             }
+            if (changed) OnPropertyChanged(nameof(WorldXY));
         }
 
         private void onImagePropertyChanged(object sender, PropertyChangedEventArgs args)

--- a/Source/Engine/AGS.Engine/Objects/Transform/AGSWorldPositionComponent.cs
+++ b/Source/Engine/AGS.Engine/Objects/Transform/AGSWorldPositionComponent.cs
@@ -1,0 +1,67 @@
+﻿using System.ComponentModel;
+using AGS.API;
+using PropertyChanged;
+
+namespace AGS.Engine
+{
+    [RequiredComponent(typeof(IBoundingBoxComponent))]
+    [RequiredComponent(typeof(IImageComponent))]
+    public class AGSWorldPositionComponent : AGSComponent, IWorldPositionComponent
+    {
+        private float _worldX, _worldY;
+        private IBoundingBoxComponent _box;
+        private IImageComponent _image;
+
+		public override void Init(IEntity entity)
+		{
+            base.Init(entity);
+            entity.Bind<IBoundingBoxComponent>(
+                c => { _box = c; c.OnBoundingBoxesChanged.Subscribe(refresh); refresh(); },
+                _ => _box = null);
+            entity.Bind<IImageComponent>(
+                c => { _image = c; c.PropertyChanged += onImagePropertyChanged; refresh(); },
+                _ => _image = null);
+		}
+
+        [DoNotNotify]
+		public float WorldX 
+        { 
+            get => _worldX;
+            //todo: set
+        }
+
+        [DoNotNotify]
+        public float WorldY 
+        { 
+            get => _worldY;
+            //todo: set
+        }
+
+        private void refresh()
+        {
+            var boxComponent = _box;
+            var image = _image;
+            if (boxComponent == null || image == null) return;
+            var box = _box.HitTestBoundingBox;
+            var pivot = _image.Pivot;
+            var oldX = _worldX;
+            var oldY = _worldY;
+            _worldX = MathUtils.Lerp(0f, box.MinX, 1f, box.MaxX, pivot.X);
+            _worldY = MathUtils.Lerp(0f, box.MinY, 1f, box.MaxY, pivot.Y);
+            if (!MathUtils.FloatEquals(oldX, _worldX))
+            {
+                OnPropertyChanged(nameof(WorldX));
+            }
+            if (!MathUtils.FloatEquals(oldY, _worldY))
+            {
+                OnPropertyChanged(nameof(WorldY));
+            }
+        }
+
+        private void onImagePropertyChanged(object sender, PropertyChangedEventArgs args)
+        {
+            if (args.PropertyName != nameof(IImageComponent.Pivot)) return;
+            refresh();
+        }
+    }
+}

--- a/Source/Engine/AGS.Engine/Objects/Transform/AGSWorldPositionComponent.cs
+++ b/Source/Engine/AGS.Engine/Objects/Transform/AGSWorldPositionComponent.cs
@@ -47,7 +47,7 @@ namespace AGS.Engine
             var boxComponent = _box;
             var image = _image;
             if (boxComponent == null || image == null) return;
-            var box = _box.HitTestBoundingBox;
+            var box = _box.WorldBoundingBox;
             var pivot = _image.Pivot;
             var oldXY = _worldXY;
             var worldX = MathUtils.Lerp(0f, box.MinX, 1f, box.MaxX, pivot.X);

--- a/Source/Engine/AGS.Engine/Rooms/Viewport/AGSCamera.cs
+++ b/Source/Engine/AGS.Engine/Rooms/Viewport/AGSCamera.cs
@@ -51,7 +51,7 @@ namespace AGS.Engine
 
 			setScale(target, viewport, resetPosition);
 
-            var box = target.HitTestBoundingBox;
+            var box = target.WorldBoundingBox;
             var targetPoint = TargetPoint;
             float targetX = targetPoint == null ? target.WorldX : MathUtils.Lerp(0f, box.MinX, 1f, box.MaxX, targetPoint.Value.X);
             float targetY = targetPoint == null ? target.WorldY : MathUtils.Lerp(0f, box.MinY, 1f, box.MaxY, targetPoint.Value.Y);

--- a/Source/Engine/AGS.Engine/UI/Controls/Panel/AGSCropChildrenComponent.cs
+++ b/Source/Engine/AGS.Engine/UI/Controls/Panel/AGSCropChildrenComponent.cs
@@ -172,7 +172,7 @@ namespace AGS.Engine
                 if (cropSelf == null)
                 {
                     cropSelf = new AGSCropSelfComponent();
-                    ChildCropper cropper = new ChildCropper("Label: " + obj.ID, () => _isDirty, cropSelf, () => boundingBoxes.RenderBox);
+                    ChildCropper cropper = new ChildCropper("Label: " + obj.ID, () => _isDirty, cropSelf, () => boundingBoxes.ViewportBox);
                     cropSelf.OnBeforeCrop.Subscribe(cropper.CropIfNeeded);
                     cropSelf.Init(obj);
                     cropSelf.AfterInit();
@@ -184,7 +184,7 @@ namespace AGS.Engine
             {
                 cropSelf = new AGSCropSelfComponent();
                 cropSelf.CropEnabled = false;
-                ChildCropper cropper = new ChildCropper(obj.ID, () => _isDirty, cropSelf, () => boundingBoxes.RenderBox);
+                ChildCropper cropper = new ChildCropper(obj.ID, () => _isDirty, cropSelf, () => boundingBoxes.ViewportBox);
                 cropSelf.OnBeforeCrop.Subscribe(cropper.CropIfNeeded);
                 obj.AddComponent<ICropSelfComponent>(cropSelf);
             }

--- a/Source/Engine/AGS.Engine/UI/Controls/Panel/AGSScrollingComponent.cs
+++ b/Source/Engine/AGS.Engine/UI/Controls/Panel/AGSScrollingComponent.cs
@@ -77,7 +77,7 @@ namespace AGS.Engine
         private void refreshSliderLimits()
         {
             if (_inEvent) return;
-            var container = _boundingBox?.GetBoundingBoxes(_state.Viewport)?.RenderBox;
+            var container = _boundingBox?.GetBoundingBoxes(_state.Viewport)?.ViewportBox;
             var withChildren = _boundingBoxWithChildren?.PreCropBoundingBoxWithChildren;
             if (container == null || !container.Value.IsValid || withChildren == null || !withChildren.Value.IsValid) return;
 

--- a/Source/Engine/AGS.Engine/UI/Controls/Panel/AGSSplitPanelComponent.cs
+++ b/Source/Engine/AGS.Engine/UI/Controls/Panel/AGSSplitPanelComponent.cs
@@ -121,7 +121,7 @@ namespace AGS.Engine
         private void positionSplitLine(IObject splitLine, IPanel topPanel, float lineWidth)
         {
 			var boundingBoxes = topPanel.GetBoundingBoxes(_state.Viewport);
-			var box = boundingBoxes.RenderBox;
+			var box = boundingBoxes.ViewportBox;
 			float width = IsHorizontal ? lineWidth : box.Width;
 			float height = IsHorizontal ? box.Height : lineWidth;
 			splitLine.Image = new EmptyImage(width, height);

--- a/Source/Engine/AGS.Engine/UI/Controls/Slider/AGSSliderComponent.cs
+++ b/Source/Engine/AGS.Engine/UI/Controls/Slider/AGSSliderComponent.cs
@@ -278,11 +278,11 @@ namespace AGS.Engine
 		{
             var boundingBox = _boundingBox;
             if (boundingBox == null) return;
-            var boundingBoxes = boundingBox.GetBoundingBoxes(_state.Viewport);
+            var hitTestBox = boundingBox.HitTestBoundingBox;
             var visible = _visible;
             var enabled = _enabled;
             if (visible == null || !visible.Visible || enabled == null || !enabled.Enabled || 
-                enabled.ClickThrough || boundingBoxes == null || 
+                enabled.ClickThrough ||
                 (!_input.LeftMouseButtonDown && !_input.IsTouchDrag) || Graphics == null || 
                 Graphics.GetBoundingBoxes(_state.Viewport) == null || HandleGraphics == null)
 			{
@@ -300,10 +300,10 @@ namespace AGS.Engine
             }
             _focus.HasKeyboardFocus = _entity;
 			_isSliding = true;
-            if (isHorizontal()) setValue(getSliderValue(MathUtils.Clamp(_input.MousePosition.XMainViewport - boundingBoxes.HitTestBox.MinX, 
-                                                                      0f, boundingBoxes.HitTestBox.Width), boundingBoxes));
-            else setValue(getSliderValue(MathUtils.Clamp(_input.MousePosition.YMainViewport - boundingBoxes.HitTestBox.MinY
-                                                         , 0f, boundingBoxes.HitTestBox.Height), boundingBoxes));
+            if (isHorizontal()) setValue(getSliderValue(MathUtils.Clamp(_input.MousePosition.XMainViewport - hitTestBox.MinX, 
+                                                                        0f, hitTestBox.Width), ref hitTestBox));
+            else setValue(getSliderValue(MathUtils.Clamp(_input.MousePosition.YMainViewport - hitTestBox.MinY
+                                                         , 0f, hitTestBox.Height), ref hitTestBox));
 		}
 
 		private void refresh()
@@ -322,12 +322,12 @@ namespace AGS.Engine
 			setText();
 		}
 
-        private float getSliderValue(float handlePos, AGSBoundingBoxes boundingBoxes)
+        private float getSliderValue(float handlePos, ref AGSBoundingBox hitTestBox)
 		{
             float min = isReverse() ? MaxValue : MinValue;
             float max = isReverse() ? MinValue : MaxValue;
             return MathUtils.Lerp(0f, min, isHorizontal() ? 
-                                  boundingBoxes.HitTestBox.Width : boundingBoxes.HitTestBox.Height, 
+                                  hitTestBox.Width : hitTestBox.Height, 
                                   max, handlePos);
 		}
 

--- a/Source/Engine/AGS.Engine/UI/Controls/Slider/AGSSliderComponent.cs
+++ b/Source/Engine/AGS.Engine/UI/Controls/Slider/AGSSliderComponent.cs
@@ -278,7 +278,7 @@ namespace AGS.Engine
 		{
             var boundingBox = _boundingBox;
             if (boundingBox == null) return;
-            var hitTestBox = boundingBox.HitTestBoundingBox;
+            var hitTestBox = boundingBox.WorldBoundingBox;
             var visible = _visible;
             var enabled = _enabled;
             if (visible == null || !visible.Visible || enabled == null || !enabled.Enabled || 
@@ -317,8 +317,8 @@ namespace AGS.Engine
             if (MathUtils.FloatEquals(MinValue, MaxValue)) return;
 
             var handlePos = getHandlePos(Value, scale);
-            if (isHorizontal()) HandleGraphics.X = MathUtils.Clamp(handlePos, 0f, boundingBoxes.RenderBox.Width);
-            else HandleGraphics.Y = MathUtils.Clamp(handlePos, 0f, boundingBoxes.RenderBox.Height);
+            if (isHorizontal()) HandleGraphics.X = MathUtils.Clamp(handlePos, 0f, boundingBoxes.ViewportBox.Width);
+            else HandleGraphics.Y = MathUtils.Clamp(handlePos, 0f, boundingBoxes.ViewportBox.Height);
 			setText();
 		}
 

--- a/Source/Engine/AGS.Engine/UI/Text/GLLabelRenderer.cs
+++ b/Source/Engine/AGS.Engine/UI/Text/GLLabelRenderer.cs
@@ -149,8 +149,8 @@ namespace AGS.Engine
                 _labelBoundingBoxFakeBuilder.BoundingBoxes = _usedLabelBoundingBoxes;
             }
             _bgRenderer.Prepare(obj, drawable, viewport);
-            Width = _usedLabelBoundingBoxes == null ? 1f : _usedLabelBoundingBoxes.RenderBox.Width;
-            Height = _usedLabelBoundingBoxes == null ? 1f : _usedLabelBoundingBoxes.RenderBox.Height;
+            Width = _usedLabelBoundingBoxes == null ? 1f : _usedLabelBoundingBoxes.ViewportBox.Width;
+            Height = _usedLabelBoundingBoxes == null ? 1f : _usedLabelBoundingBoxes.ViewportBox.Height;
 		}
 
         public void Render(IObject obj, IViewport viewport)
@@ -178,10 +178,10 @@ namespace AGS.Engine
                 _glUtils.AdjustResolution(resolution.Width, resolution.Height);
 
                 IGLColor color = _colorBuilder.Build(Colors.White);
-                var cropInfo = _usedTextBoundingBoxes.RenderBox.Crop(BoundingBoxType.Render, CustomTextCrop ?? obj.GetComponent<ICropSelfComponent>(), AGSModelMatrixComponent.NoScaling);
+                var cropInfo = _usedTextBoundingBoxes.ViewportBox.Crop(BoundingBoxType.Render, CustomTextCrop ?? obj.GetComponent<ICropSelfComponent>(), AGSModelMatrixComponent.NoScaling);
                 if (cropInfo.Equals(_defaultCrop)) return;
 
-                _afterCropTextBoundingBoxes.RenderBox = cropInfo.BoundingBox;
+                _afterCropTextBoundingBoxes.ViewportBox = cropInfo.BoundingBox;
                 _afterCropTextBoundingBoxes.TextureBox = cropInfo.TextureBox;
 
                 _textureRenderer.Render(_glTextHitTest.Texture, _afterCropTextBoundingBoxes, color);
@@ -390,13 +390,13 @@ namespace AGS.Engine
             var intermediateBox = _boundingBoxBuilder.BuildIntermediateBox(width, height, ref modelMatrix);
             if (buildHitTestBox)
             {
-                boxes.HitTestBox = _boundingBoxBuilder.BuildHitTestBox(ref intermediateBox);
+                boxes.WorldBox = _boundingBoxBuilder.BuildHitTestBox(ref intermediateBox);
             }
             if (buildRenderBox)
             {
                 PointF scale;
                 var viewportMatrix = matrices.ViewportMatrix;
-                boxes.RenderBox = _boundingBoxBuilder.BuildRenderBox(ref intermediateBox, ref viewportMatrix, out scale);
+                boxes.ViewportBox = _boundingBoxBuilder.BuildRenderBox(ref intermediateBox, ref viewportMatrix, out scale);
             }
         }
 
@@ -438,12 +438,12 @@ namespace AGS.Engine
 
             public AGSBoundingBox BuildIntermediateBox(float width, float height, ref Matrix4 modelMatrix) => default;
 
-            public AGSBoundingBox BuildHitTestBox(ref AGSBoundingBox intermediateBox) => BoundingBoxes?.HitTestBox ?? default;
+            public AGSBoundingBox BuildHitTestBox(ref AGSBoundingBox intermediateBox) => BoundingBoxes?.WorldBox ?? default;
 
             public AGSBoundingBox BuildRenderBox(ref AGSBoundingBox intermediateBox, ref Matrix4 viewportMatrix, out PointF scale)
             {
                 scale = AGSModelMatrixComponent.NoScaling;
-                return BoundingBoxes?.RenderBox ?? default;
+                return BoundingBoxes?.ViewportBox ?? default;
             }
 
 			#endregion

--- a/Source/Tests/Engine/Rooms/Viewport/CameraTests.cs
+++ b/Source/Tests/Engine/Rooms/Viewport/CameraTests.cs
@@ -45,8 +45,8 @@ namespace Tests
 			int roomWidth, int screenWidth, float speedX)
 		{
 			AGSCamera camera = new AGSCamera (speedX, 0f);
-			_mocks.Object().Setup(o => o.X).Returns(targetPosX);
-			_mocks.Object().Setup(o => o.Y).Returns(0f);
+			_mocks.Object().Setup(o => o.WorldX).Returns(targetPosX);
+			_mocks.Object().Setup(o => o.WorldY).Returns(0f);
 			Func<IObject> getTarget = () => _mocks.Object().Object;
 			camera.Target = getTarget;
             AGSViewport viewport = new AGSViewport(new AGSDisplayListSettings(), camera, Mocks.GetResolver());

--- a/Source/Tests/Mocks.cs
+++ b/Source/Tests/Mocks.cs
@@ -55,6 +55,7 @@ namespace Tests
 			builder.RegisterInstance(new Mock<IRenderMessagePump> ().Object);
             builder.RegisterInstance(new Mock<IUpdateMessagePump>().Object);
             builder.RegisterInstance(new Mock<IGameEvents>().Object);
+            builder.RegisterInstance(new Mock<IDisplayList>().Object);
 			builder.RegisterSource(new AnyConcreteTypeNotAlreadyRegisteredSource());
 
 			mocks.container = builder.Build();


### PR DESCRIPTION
1. Created world position component that allows getting the world position (as opposed to the local position).
2. Used that component in several places to use world position and not local position.
3. Added a target position property to the built in camera to allow control over which point in the target itself the camera should focus on.
4. Refactoring- renamed hit-test bounding box and render bounding box to world bounding box and viewport bounding box. Added a property for getting the world bounding box which doesn't require passing in the viewport.

Fixes #271 