### PR TITLE
Resources- changing root path

### DIFF
--- a/Source/AGS.API/Audio/ISoundEmitter.cs
+++ b/Source/AGS.API/Audio/ISoundEmitter.cs
@@ -9,7 +9,7 @@
     /// </summary>
     /// <example>
     /// <code language="lang-csharp">
-    /// var footstep = await game.Factory.Sound.LoadAudioClipAsync("../../Assets/Sounds/footstep.ogg");
+    /// var footstep = await game.Factory.Sound.LoadAudioClipAsync("Sounds/footstep.ogg");
     /// ISoundEmitter emitter = new AGSSoundEmitter(game);
     /// emitter.AudioClip = footstep;
     /// emitter.Object = cHero;

--- a/Source/AGS.API/Misc/Resources/IResourceLoader.cs
+++ b/Source/AGS.API/Misc/Resources/IResourceLoader.cs
@@ -27,12 +27,11 @@ namespace AGS.API
     /// 
     /// The path used by the loading methods has to be structured as so: if the resource is to be loaded from a file 
     /// in the file system, then put the absolute path of the file. If the resource is embedded then put the relative 
-    /// path of the file (when the current folder is the folder where the executable sits, which is 2 folders above 
-    /// the "Assets" folder). So, for example, if you have an audio file called "trumpet.ogg" sitting under a 
-    /// "Sounds" folder in "Assets", your path would be "../../Assets/Sounds/trumpet.ogg". Note that this would 
-    /// work even if the file is sitting in that folder but not embedded. This is because `ResourceLoader` first 
-    /// searches for an embedded resource with that path, but if one is not found, it looks for the file in the 
-    /// file system.
+    /// path of the file (when the current folder is the "Assets" folder). So, for example, if you have an audio file called "trumpet.ogg" sitting under a 
+    /// "Sounds" folder in "Assets", your path would be "Sounds/trumpet.ogg". Note that this would 
+    /// work even if the file is sitting in that folder but not embedded. This is because (assuming the resource loader is configured
+    /// with both an embedded resource pack and a file system resource pack) `ResourceLoader` will search for both an embedded resource and for 
+    /// a file from the file system. The order of the search depends on the configured priority for each resource pack.
     /// </summary>
     public interface IResourceLoader : IResourcePack
 	{
@@ -80,4 +79,3 @@ namespace AGS.API
         public int Priority { get; private set; }
     }
 }
-

--- a/Source/Demo/DemoQuest/Characters/Beman.cs
+++ b/Source/Demo/DemoQuest/Characters/Beman.cs
@@ -73,4 +73,3 @@ namespace DemoGame
 		}
 	}
 }
-

--- a/Source/Demo/DemoQuest/Characters/Beman.cs
+++ b/Source/Demo/DemoQuest/Characters/Beman.cs
@@ -7,7 +7,7 @@ namespace DemoGame
     public class Beman
 	{
 		private ICharacter _character;
-		private const string _baseFolder = "../../Assets/Characters/Beman/";
+		private const string _baseFolder = "Characters/Beman/";
 		private BemanDialogs _dialogs = new BemanDialogs();
 		private IGame _game;
 

--- a/Source/Demo/DemoQuest/Characters/Cris.cs
+++ b/Source/Demo/DemoQuest/Characters/Cris.cs
@@ -7,13 +7,13 @@ namespace DemoGame
     public class Cris
 	{
 		private ICharacter _character;
-		private const string _baseFolder = "../../Assets/Characters/Cris/";
+		private const string _baseFolder = "Characters/Cris/";
 
 		public async Task<ICharacter> LoadAsync(IGame game)
 		{
             AGSLoadImageConfig loadConfig = new AGSLoadImageConfig(new AGS.API.Point(0, 0));
 
-			var footstep = await game.Factory.Sound.LoadAudioClipAsync("../../Assets/Sounds/151238__owlstorm__hard-female-footstep-2.wav");
+			var footstep = await game.Factory.Sound.LoadAudioClipAsync("Sounds/151238__owlstorm__hard-female-footstep-2.wav");
 			ISoundEmitter emitter = new AGSSoundEmitter (game);
 			emitter.AudioClip = footstep;
 

--- a/Source/Demo/DemoQuest/Characters/Cris.cs
+++ b/Source/Demo/DemoQuest/Characters/Cris.cs
@@ -55,4 +55,3 @@ namespace DemoGame
 		}
 	}
 }
-

--- a/Source/Demo/DemoQuest/GUI/InventoryItems.cs
+++ b/Source/Demo/DemoQuest/GUI/InventoryItems.cs
@@ -7,7 +7,7 @@ namespace DemoGame
 {
 	public class InventoryItems
 	{
-		private const string _baseFolder = "../../Assets/Inventory/";
+		private const string _baseFolder = "Inventory/";
 
 		public static IInventoryItem Bottle { get; private set; }
 		public static IInventoryItem VoodooDoll { get; private set; }
@@ -17,7 +17,7 @@ namespace DemoGame
 		public async Task LoadAsync(IGameFactory factory)
 		{
             AGSLoadImageConfig loadConfig = new AGSLoadImageConfig(new AGS.API.Point(0, 0));
-			Bottle = await factory.Inventory.GetInventoryItemAsync("Bottle", "../../Assets/Rooms/EmptyStreet/bottle.bmp", null, loadConfig);
+			Bottle = await factory.Inventory.GetInventoryItemAsync("Bottle", "Rooms/EmptyStreet/bottle.bmp", null, loadConfig);
 			VoodooDoll = await factory.Inventory.GetInventoryItemAsync("Voodoo Doll", _baseFolder + "voodooDoll.bmp", null, loadConfig, true);
 			Poster = await factory.Inventory.GetInventoryItemAsync("Poster", _baseFolder + "poster.bmp", playerStartsWithItem: true);
 			Manual = await factory.Inventory.GetInventoryItemAsync("Manual", _baseFolder + "manual.bmp", null, loadConfig, true);

--- a/Source/Demo/DemoQuest/GUI/InventoryPanel.cs
+++ b/Source/Demo/DemoQuest/GUI/InventoryPanel.cs
@@ -6,7 +6,7 @@ namespace DemoGame
 {
 	public class InventoryPanel
 	{
-		private const string _baseFolder = "../../Assets/Gui/Buttons/";
+		private const string _baseFolder = "Gui/Buttons/";
 		private IPanel _panel;
 		private readonly RotatingCursorScheme _scheme;
 		private string _lastMode;
@@ -24,7 +24,7 @@ namespace DemoGame
             _game.Events.OnSavedGameLoad.Subscribe(onSaveGameLoaded);
 			IGameFactory factory = game.Factory;
 
-			_panel = await factory.UI.GetPanelAsync("Inventory Panel", "../../Assets/Gui/DialogBox/inventory.bmp", 160f, 100f);
+			_panel = await factory.UI.GetPanelAsync("Inventory Panel", "Gui/DialogBox/inventory.bmp", 160f, 100f);
 			_panel.Pivot = new PointF (0.5f, 0.5f);
 			_panel.Visible = false;
 

--- a/Source/Demo/DemoQuest/GUI/InventoryPanel.cs
+++ b/Source/Demo/DemoQuest/GUI/InventoryPanel.cs
@@ -81,4 +81,3 @@ namespace DemoGame
 		}
 	}
 }
-

--- a/Source/Demo/DemoQuest/GUI/MouseCursors.cs
+++ b/Source/Demo/DemoQuest/GUI/MouseCursors.cs
@@ -56,4 +56,3 @@ namespace DemoGame
 		}
 	}
 }
-

--- a/Source/Demo/DemoQuest/GUI/MouseCursors.cs
+++ b/Source/Demo/DemoQuest/GUI/MouseCursors.cs
@@ -7,7 +7,7 @@ namespace DemoGame
 {
 	public class MouseCursors
 	{
-		private const string _baseFolder = "../../Assets/Gui/Cursors/";
+		private const string _baseFolder = "Gui/Cursors/";
 		private readonly AGSLoadImageConfig _loadConfig;
 
 		public MouseCursors()

--- a/Source/Demo/DemoQuest/GUI/OptionsPanel.cs
+++ b/Source/Demo/DemoQuest/GUI/OptionsPanel.cs
@@ -7,7 +7,7 @@ namespace DemoGame
 {
     public class OptionsPanel
     {
-        private const string _sliderFolder = "../../Assets/Gui/Sliders/";
+        private const string _sliderFolder = "Gui/Sliders/";
         private const string _panelId = "Options Panel";
         private const string _buttonsPanelId = "Options Buttons Panel";
         private IPanel _panel, _buttonsPanel;
@@ -34,7 +34,7 @@ namespace DemoGame
         {
             _game = game;
             IGameFactory factory = game.Factory;
-            _panel = await factory.UI.GetPanelAsync(_panelId, "../../Assets/Gui/DialogBox/options.bmp", 160f, 100f);
+            _panel = await factory.UI.GetPanelAsync(_panelId, "Gui/DialogBox/options.bmp", 160f, 100f);
             _panel.Pivot = new PointF(0.5f, 0.5f);
             _panel.Visible = false;
             _panel.AddComponent<IModalWindowComponent>();
@@ -93,7 +93,7 @@ namespace DemoGame
 
 		private async Task loadButton(string text, Action onClick)
 		{
-			const string folder = "../../Assets/Gui/Buttons/buttonSmall/";
+			const string folder = "Gui/Buttons/buttonSmall/";
 			string buttonId = $"{text} Button";
 			IButton button = await _game.Factory.UI.GetButtonAsync(buttonId, folder + "normal.bmp", folder + "hovered.bmp",
                folder + "pushed.bmp", 15f, 0f, _buttonsPanel, text, _buttonTextConfig);

--- a/Source/Demo/DemoQuest/GUI/TopBar.cs
+++ b/Source/Demo/DemoQuest/GUI/TopBar.cs
@@ -6,7 +6,7 @@ namespace DemoGame
 {
 	public class TopBar
 	{
-		private const string _baseFolder = "../../Assets/Gui/Buttons/";
+		private const string _baseFolder = "Gui/Buttons/";
 		private IPanel _panel;
 		private readonly RotatingCursorScheme _scheme;
 		private InventoryPanel _invPanel;
@@ -35,7 +35,7 @@ namespace DemoGame
             _game.Events.OnSavedGameLoad.Subscribe(onSaveGameLoaded);
 			IGameFactory factory = game.Factory;
 			_player = game.State.Player;
-			_panel = await factory.UI.GetPanelAsync("Toolbar", "../../Assets/Gui/DialogBox/toolbar.bmp", 0f, 180f);
+			_panel = await factory.UI.GetPanelAsync("Toolbar", "Gui/DialogBox/toolbar.bmp", 0f, 180f);
 			_panel.Visible = false;
 
 			await loadButton("Walk Button", factory, "walk/", 0f, RotatingCursorScheme.WALK_MODE);

--- a/Source/Demo/DemoQuest/GUI/TopBar.cs
+++ b/Source/Demo/DemoQuest/GUI/TopBar.cs
@@ -111,4 +111,3 @@ namespace DemoGame
 		}
 	}
 }
-

--- a/Source/Demo/DemoQuest/Program.cs
+++ b/Source/Demo/DemoQuest/Program.cs
@@ -20,11 +20,11 @@ namespace DemoGame
 
             game.Events.OnLoad.Subscribe(async () =>
             {
-                game.Factory.Resources.ResourcePacks.Add(new ResourcePack(new FileSystemResourcePack(AGSGame.Device.FileSystem), 0));
+                game.Factory.Resources.ResourcePacks.Add(new ResourcePack(new FileSystemResourcePack(AGSGame.Device.FileSystem, AGSGame.Device.Assemblies.EntryAssembly), 0));
                 game.Factory.Resources.ResourcePacks.Add(new ResourcePack(new EmbeddedResourcesPack(AGSGame.Device.Assemblies.EntryAssembly), 1));
-                game.Factory.Fonts.InstallFonts("../../Assets/Fonts/pf_ronda_seven.ttf", "../../Assets/Fonts/Pixel_Berry_08_84_Ltd.Edition.TTF");
-                AGSGameSettings.DefaultSpeechFont = game.Factory.Fonts.LoadFontFromPath("../../Assets/Fonts/pf_ronda_seven.ttf", 14f, FontStyle.Regular);
-                AGSGameSettings.DefaultTextFont = game.Factory.Fonts.LoadFontFromPath("../../Assets/Fonts/Pixel_Berry_08_84_Ltd.Edition.TTF", 14f, FontStyle.Regular);
+                game.Factory.Fonts.InstallFonts("Fonts/pf_ronda_seven.ttf", "Fonts/Pixel_Berry_08_84_Ltd.Edition.TTF");
+                AGSGameSettings.DefaultSpeechFont = game.Factory.Fonts.LoadFontFromPath("Fonts/pf_ronda_seven.ttf", 14f, FontStyle.Regular);
+                AGSGameSettings.DefaultTextFont = game.Factory.Fonts.LoadFontFromPath("Fonts/Pixel_Berry_08_84_Ltd.Edition.TTF", 14f, FontStyle.Regular);
                 AGSGameSettings.CurrentSkin = null;
                 game.State.RoomTransitions.Transition = AGSRoomTransitions.Fade();
                 setKeyboardEvents(game);

--- a/Source/Demo/DemoQuest/Rooms/BrokenCurbStreet.cs
+++ b/Source/Demo/DemoQuest/Rooms/BrokenCurbStreet.cs
@@ -96,4 +96,3 @@ namespace DemoGame
 		}
 	}
 }
-

--- a/Source/Demo/DemoQuest/Rooms/BrokenCurbStreet.cs
+++ b/Source/Demo/DemoQuest/Rooms/BrokenCurbStreet.cs
@@ -10,7 +10,7 @@ namespace DemoGame
         private ICharacter _player;
 		private IGame _game;
 
-		private const string _baseFolder = "../../Assets/Rooms/BrokenCurbStreet/";
+		private const string _baseFolder = "Rooms/BrokenCurbStreet/";
 
 		public async Task<IRoom> LoadAsync(IGame game)
 		{
@@ -21,7 +21,7 @@ namespace DemoGame
 			_room = factory.Room.GetRoom ("Broken Curb Street", 20f, 310f, 190f, 10f);
 
             //todo: temporary removed loading the flac file as it crashes on windows after migrating to dotnet standard
-			//_room.MusicOnLoad = await factory.Sound.LoadAudioClipAsync("../../Assets/Sounds/01_Ghosts_I.flac");
+			//_room.MusicOnLoad = await factory.Sound.LoadAudioClipAsync("Sounds/01_Ghosts_I.flac");
 
 			IObject bg = factory.Object.GetObject("Broken Curb BG");
 			bg.Image = await factory.Graphics.LoadImageAsync(_baseFolder + "bg.png");

--- a/Source/Demo/DemoQuest/Rooms/DarsStreet.cs
+++ b/Source/Demo/DemoQuest/Rooms/DarsStreet.cs
@@ -137,4 +137,3 @@ namespace DemoGame
 		}
 	}
 }
-

--- a/Source/Demo/DemoQuest/Rooms/DarsStreet.cs
+++ b/Source/Demo/DemoQuest/Rooms/DarsStreet.cs
@@ -10,7 +10,7 @@ namespace DemoGame
         private ICharacter _player;
 		private IGame _game;
 
-		private const string _baseFolder = "../../Assets/Rooms/DarsStreet/";
+		private const string _baseFolder = "Rooms/DarsStreet/";
 
 		public async Task<IRoom> LoadAsync(IGame game)
 		{

--- a/Source/Demo/DemoQuest/Rooms/EmptyStreet.cs
+++ b/Source/Demo/DemoQuest/Rooms/EmptyStreet.cs
@@ -108,4 +108,3 @@ namespace DemoGame
 		}
 	}
 }
-

--- a/Source/Demo/DemoQuest/Rooms/EmptyStreet.cs
+++ b/Source/Demo/DemoQuest/Rooms/EmptyStreet.cs
@@ -12,7 +12,7 @@ namespace DemoGame
 		private IGame _game;
 		private IAudioClip _bottleEffectClip;
 
-		private const string _baseFolder = "../../Assets/Rooms/EmptyStreet/";
+		private const string _baseFolder = "Rooms/EmptyStreet/";
 		private const string _roomId = "Empty Street";
 		private const string _bottleId = "Bottle (object)";
 
@@ -25,11 +25,11 @@ namespace DemoGame
 		{
 			_game = game;
 			IGameFactory factory = game.Factory;
-			_bottleEffectClip = await factory.Sound.LoadAudioClipAsync("../../Assets/Sounds/254818__kwahmah-02__rattling-glass-bottles-impact.wav");
+			_bottleEffectClip = await factory.Sound.LoadAudioClipAsync("Sounds/254818__kwahmah-02__rattling-glass-bottles-impact.wav");
 
             ILoadImageConfig loadConfig = new AGSLoadImageConfig(new Point(0, 0));
 			_room = factory.Room.GetRoom(_roomId, 20f, 310f, 190f, 10f);
-			_room.MusicOnLoad = await factory.Sound.LoadAudioClipAsync("../../Assets/Sounds/AMemoryAway.ogg");
+			_room.MusicOnLoad = await factory.Sound.LoadAudioClipAsync("Sounds/AMemoryAway.ogg");
 
             _game.Events.OnSavedGameLoad.Subscribe(onSavedGameLoaded);
 

--- a/Source/Demo/DemoQuest/Rooms/TrashcanStreet.cs
+++ b/Source/Demo/DemoQuest/Rooms/TrashcanStreet.cs
@@ -10,7 +10,7 @@ namespace DemoGame
         private ICharacter _player;
 		private IGame _game;
 
-		private const string _baseFolder = "../../Assets/Rooms/TrashcanStreet/";
+		private const string _baseFolder = "Rooms/TrashcanStreet/";
 
 		public async Task<IRoom> LoadAsync(IGame game)
 		{

--- a/Source/Demo/DemoQuest/Rooms/TrashcanStreet.cs
+++ b/Source/Demo/DemoQuest/Rooms/TrashcanStreet.cs
@@ -67,4 +67,3 @@ namespace DemoGame
 		}
 	}
 }
-

--- a/Source/Engine/AGS.Engine.Desktop/DesktopDevice.cs
+++ b/Source/Engine/AGS.Engine.Desktop/DesktopDevice.cs
@@ -40,7 +40,7 @@ namespace AGS.Engine.Desktop
         private IResourceLoader getResourceLoader()
         {
             ResourceLoader resourceLoader = new ResourceLoader();
-            FileSystemResourcePack fileResourcePack = new FileSystemResourcePack(FileSystem);
+            FileSystemResourcePack fileResourcePack = new FileSystemResourcePack(FileSystem, Assemblies.EntryAssembly);
             EmbeddedResourcesPack embeddedResourcePack = new EmbeddedResourcesPack(Assemblies.EntryAssembly);
             resourceLoader.ResourcePacks.Add(new ResourcePack(fileResourcePack, 0));
             resourceLoader.ResourcePacks.Add(new ResourcePack(embeddedResourcePack, 1));

--- a/Source/Engine/AGS.Engine/Audio/AGSClassicSpeechCache.cs
+++ b/Source/Engine/AGS.Engine/Audio/AGSClassicSpeechCache.cs
@@ -11,7 +11,7 @@ namespace AGS.Engine
     {
         private IAudioFactory _factory;
         private ConcurrentDictionary<string, IAudioClip> _speechCache;
-        private const string _baseFolder = "../../Assets/Speech/English/";
+        private const string _baseFolder = "Speech/English/";
 
         public AGSClassicSpeechCache(IAudioFactory factory)
         {

--- a/Source/Engine/AGS.Engine/Audio/AGSClassicSpeechCache.cs
+++ b/Source/Engine/AGS.Engine/Audio/AGSClassicSpeechCache.cs
@@ -48,4 +48,3 @@ namespace AGS.Engine
         }
     }
 }
-

--- a/Source/Engine/AGS.Engine/Misc/Resources/EmbeddedResourcesPack.cs
+++ b/Source/Engine/AGS.Engine/Misc/Resources/EmbeddedResourcesPack.cs
@@ -73,12 +73,9 @@ namespace AGS.Engine
         {
             try
             {
-                int assetsIndex = path.IndexOf(AssetsFolder, StringComparison.Ordinal);
-                if (assetsIndex < 0) return null;
-                string resourcePath = path.Substring(assetsIndex);
-                resourcePath = resourcePath.Replace('/', '.').Replace('\\', '.');
-                resourcePath = $"{_assemblyName}.{resourcePath}";
-                return resourcePath;
+                path = path.Replace('/', '.').Replace('\\', '.');
+                path = $"{_assemblyName}.{AssetsFolder}.{path}";
+                return path;
             }
             catch (Exception e)
             {

--- a/Source/Engine/AGS.Engine/Misc/Resources/FileSystemResourcePack.cs
+++ b/Source/Engine/AGS.Engine/Misc/Resources/FileSystemResourcePack.cs
@@ -90,7 +90,7 @@ namespace AGS.Engine
 
         private string autoDetectAssetsFolder(Assembly assembly)
         {
-            string exeDir = Path.GetDirectoryName(assembly.GetName().CodeBase);
+            string exeDir = assembly == null ? _fileSystem.GetCurrentDirectory() : Path.GetDirectoryName(assembly.GetName().CodeBase);
             string dir = exeDir;
             while (true)
             {

--- a/Source/Engine/AGS.Engine/Misc/Resources/FileSystemResourcePack.cs
+++ b/Source/Engine/AGS.Engine/Misc/Resources/FileSystemResourcePack.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;
 using System.Linq;
+using System.Reflection;
 using AGS.API;
 
 namespace AGS.Engine
@@ -12,10 +13,19 @@ namespace AGS.Engine
         private Dictionary<string, List<string>> _externalFolders;
         private readonly Func<string, List<string>> _getFilesInFolderFunc;
         private readonly IFileSystem _fileSystem;
+        private readonly string _rootFolderPath;
 
-        public FileSystemResourcePack(IFileSystem fileSystem)
+        /// <summary>
+        /// Initializes a new instance of the <see cref="T:AGS.Engine.FileSystemResourcePack"/> class.
+        /// </summary>
+        /// <param name="fileSystem">File system.</param>
+        /// <param name="assembly">The entry assembly (this will be used to figure out the root folder, if no root folder is given).</param>
+        /// <param name="rootFolderPath">The root folder from which to resolve relative paths. 
+        /// If not given the engine will try looking for the "Assets" folder itself.</param>
+        public FileSystemResourcePack(IFileSystem fileSystem, Assembly assembly, string rootFolderPath = null)
         {
             _fileSystem = fileSystem;
+            _rootFolderPath = rootFolderPath ?? autoDetectAssetsFolder(assembly);
             _externalFolders = new Dictionary<string, List<string>>(10);
             _getFilesInFolderFunc = getFilesInFolder; //Caching delegate to avoid memory allocations in critical path
         }
@@ -23,6 +33,7 @@ namespace AGS.Engine
         public string ResolvePath(string path)
         {
             if (shouldIgnoreFile(path)) return null;
+            path = getAbsolutePath(path);
             string folder = Path.GetDirectoryName(path);
             string filename = Path.GetFileName(path).ToUpper();
             if (filename.Contains(".")) return path;
@@ -43,6 +54,7 @@ namespace AGS.Engine
 
         public List<IResource> LoadResources(string folder)
         {
+            folder = getAbsolutePath(folder);
             List<IResource> resources = new List<IResource>();
             foreach (var file in _fileSystem.GetFiles(folder))
             {
@@ -52,6 +64,8 @@ namespace AGS.Engine
             }
             return resources;
         }
+
+        private string getAbsolutePath(string path) => Path.IsPathRooted(path) ? path : Path.Combine(_rootFolderPath, path);
 
         private List<string> getFilesInFolder(string folder)
         {
@@ -72,6 +86,29 @@ namespace AGS.Engine
         {
             return path == null ||
                 path.EndsWith(".DS_Store", StringComparison.Ordinal); //Mac OS file
+        }
+
+        private string autoDetectAssetsFolder(Assembly assembly)
+        {
+            string exeDir = Path.GetDirectoryName(assembly.GetName().CodeBase);
+            string dir = exeDir;
+            while (true)
+            {
+                var assetsDir = _fileSystem.GetDirectories(dir).FirstOrDefault(
+                    p => Path.GetFileName(p).ToLowerInvariant() == EmbeddedResourcesPack.AssetsFolder.ToLowerInvariant());
+                if (assetsDir != null)
+                {
+                    Debug.WriteLine($"Found assets directory at: {assetsDir}");
+                    return assetsDir;
+                }
+                DirectoryInfo dirInfo = Directory.GetParent(dir);
+                if (dirInfo == null)
+                {
+                    Debug.WriteLine($"Did not find assets directory, using executable directory: {exeDir}");
+                    return exeDir;
+                }
+                dir = dirInfo.FullName;
+            }
         }
     }
 }


### PR DESCRIPTION
1. Added an optional parameter for selecting a root path for file
system resource paths. If given it will be used for resolving relative
paths when loading resources. Fixes #288.
2. If a default path was not given, the engine will try to auto-detect
and find the “Assets” folder to act as the root folder for relative
paths (by drilling down from the executable directory until it finds a
folder with the name “Assets”). This is a BREAKING CHANGE -> this was
done because the previous assumption, that the assets folder is 2
folders upwards from the working directory was already broken: A. This
was true when running from VS but not necessarily when running from
somewhere else, and B. After switching to the new project format, the
executables are actually compiled 3 folders down (bin/net461/debug)
instead of 2 folders down (bin/debug), so running from visual studio
would also not work.
Also, this makes giving resource paths into the assets folder easier
(i.e loader.Load(“Sounds/footstep.ogg”) instead of
(“../../Assets/Sounds/footstep.ogg”).
3. The embedded resource pack was changed to be consistent with the
file system resource pack, so the assets folder is also the root for
the embedded resources now too. As all resources in the demo game are
embedded, changed the paths in all of them and removed the
“../../Assets” prefix.