### PR TITLE
Add option to give specific text position to "Say"

### DIFF
--- a/Docs/articles/ags-cheat-sheet.md
+++ b/Docs/articles/ags-cheat-sheet.md
@@ -571,7 +571,7 @@ Missing in AGS but exists in MonoAGS: ID, CurrentlyPlayingSounds, Volume/Pitch/P
 | RemoveTint | Tint | `cEgo.RemoveTint();` | `cEgo.Tint = Colors.White;` |
 | RunInteraction | Interactions.OnInteract(Verb).InvokeAsync | `cEgo.RunInteraction(eModeTalk);` | `cEgo.Interactions.OnInteract(Verbs.Talk).InvokeAsync();` |
 | Say | SayAsync | `cEgo.Say("Hello!");` | `await cEgo.SayAsync("Hello!");` |
-| SayAt | ? | `cEgo.SayAt("Hello!", 50, 50);` | ? | While there's no direct equivalent currently, this can be worked around by providing a custom implementation for `ISayLocationProvider`.
+| SayAt | ? | `cEgo.SayAt("Hello!", 50, 50);` | `await cEgo.SayAsync("Hello!", (50, 50));` |
 | SayBackground | SayAsync | `cEgo.SayBackground("Hello!");` | `cEgo.SayAsync("Hello!");` | There's no way in AGS to know when `SayBackground` completes. MonoAGS gives you the task completion API for this: `Task task = cEgo.SayAsync("Hello!"); ... while (!task.IsCompleted) {..}`, or simply: `Task task = cEgo.SayAsync("Hello!"); ... await task; `
 | SetAsPlayer | IGameState.Player | `cEgo.SetAsPlayer();` | `state.Player = cEgo;` |
 | SetIdleView | Outfit | `cEgo.SetIdleView(5);` | `cEgo.Outfit = outfitWithHat;` | Note that the concepts are not identical: `SetIdleView` in AGS changes the idle animation, where `Outfit` in MonoAGS changes all animations in that outfit (which can be walk, idle, etc).

--- a/Docs/articles/characters.md
+++ b/Docs/articles/characters.md
@@ -18,14 +18,14 @@ Please refer to the [Walking](walking.md) section for more details.
 ### Facing directions
 
 Allows your characters to face directions: either to face a specific point on screen, or face to a specific object in the room, or simply to face left, up, up-left, etc.
-This would change the current animation to use the most suited animation for the current direction (so, for example, if you face left but only has an "up", "left" or "down" animations, 
+This would change the current animation to use the most suited animation for the current direction (so, for example, if you face left but only has an "up", "left" or "down" animations,
 either "up" or "down" will be used).
 
 ### Following
 
-Allows commanding a character to follow another character/object in the room. 
+Allows commanding a character to follow another character/object in the room.
 You can configure how the character performs a follow, to be able to accommodate different scenario (a companion, a spy or an enemy, for example).
-You can configure with the time range the character will wait before commencing a new walk towards the target, what's the distance range you'd want to have your character away from the target, 
+You can configure with the time range the character will wait before commencing a new walk towards the target, what's the distance range you'd want to have your character away from the target,
 what's the probability of having your character wander off somewhere else, and whether or not the character will move between rooms if the target moves to another room.
 
 ### Approaching
@@ -39,7 +39,7 @@ or always walk towards the target (`AlwaysWalk`).
 
 ### Speaking
 
-Allows a character to speak. You'll use either `Say` or `SayAsync` for the character to speak which basically does the following:
+Allows a character to speak. You'll use `SayAsync` for the character to speak which basically does the following:
 1. Puts text on the screen for some time
 2. Change the character animation to the speaking animation
 3. Optionally display a portrait of the character
@@ -52,11 +52,12 @@ You can configure how the text is rendered (color, font, etc: see [Labels](label
 and a text offset to offset the location of the text. That offset will be relative to the default text display location which will be selected by the engine: The engine, by default, tries to place
 the text above the character and a little to the side, unless the text won't fit the screen, then it changes the location to ensure the text fits the screen.
 If you don't like that behavior you can implement your own text location by implementing the `ISayLocationProvider` interface (and hooking it up, see the section about customizability).
+You can also specify a one-time text (and/or portrait) position to `SayAsync` to replace the built-in behavior.
 
-#### Displaying portrait 
+#### Displaying portrait
 
 As for the portrait, you can configure the object which shows the portrait (this is a standard object, so it can has everything a normal object has, including animations, scaling, rotations, etc),
-plus a strategy on where to position the portrait (SpeakerPosition- on the top, either left or right based on where the speaker is standing, Alternating- top right, then top left, then top right, etc 
+plus a strategy on where to position the portrait (SpeakerPosition- on the top, either left or right based on where the speaker is standing, Alternating- top right, then top left, then top right, etc
 or Custom which leaves the portrait positioning to you) and custom offsets for both the portrait and for the text from the portrait.
 
 #### Playing the audio clip
@@ -65,7 +66,7 @@ In order to play an audio clip, the text you pass to the speech method should ha
 If the number exists, the engine will look for an audio file with the first four capital letters of your character's id followed by the number. So if the line was said by "Christopher",
 the engine will look for the file "CHRI17". Those files should be placed in a special folder, under Assets -> Speech -> English.
 Note: In future revisions we're planning on introducing multi-language support, and also other ways of building the speech "database".
-If the engine does not find the file it will not play an audio clip, and in any way the "&17" will be stripped away from the text and will not be displayed on screen. 
+If the engine does not find the file it will not play an audio clip, and in any way the "&17" will be stripped away from the text and will not be displayed on screen.
 
 ### Outfits
 
@@ -74,13 +75,13 @@ An outfit is a collection of animations that are associated with a character.
 The collection can be swapped with another collection when the character changes his look.
 
 Say, for example, your player can wear a jacket. You can create two outfits in advance, one with a jacket
-and the other without. Each outfit will have different walk, idle and speak animations (one with a jacket and 
+and the other without. Each outfit will have different walk, idle and speak animations (one with a jacket and
 the other without).
 
 There walk, idle and speak animations that the engine might look for when walking, standing still and speaking.
 Additionally you can add more animations to an outfit (like "Jump", or "Swim" for example), which you then need to draw per outfit, and will enable you
 to call your animation from whatever outfit the character is currently using.
-	
+
 ### Inventory
 
 Allows your character to carry inventory. Those are the items that the character holds in his/her (usually) imaginary bag.

--- a/Source/AGS.API/Objects/Characters/Talking/ISayComponent.cs
+++ b/Source/AGS.API/Objects/Characters/Talking/ISayComponent.cs
@@ -55,11 +55,19 @@ namespace AGS.API
         /// Task waitForTalk = cHero.SayAsync("Walking Home!");
         /// await cHero.WalkAsync(home); //character will walk and talk at the same time.
         /// await waitForTalk; //Waiting for the talk to complete before moving to the next setnence.
-        /// await cHero.SayAsync("And, I'm home!");
+        /// await cHero.SayAsync("And, I'm home!", (200, 100)); //The text for this sentence will be placed at co-ordinates (200, 100) instead of above the character's head.
         /// </code>
         /// </example>
         /// <param name="text">Text.</param>
-		Task SayAsync(string text);
+        /// <param name="textPosition">Optional position (bottom-left by default, subscribe <see cref="OnBeforeSay"/> and change the <see cref="IHasImage.Pivot"/> of the label to override it) for where the text will be placed. 
+        /// If not provided, the engine will place the text above the character's head. 
+        /// The interface for selecting the default text position (if none is passed here) is <see cref="ISayLocationProvider"/> and you
+        /// can override it if needed to provide default text (and portrait) locations.</param>
+        /// <param name="portraitPosition">Optional position for where the portrait will be placed (if there is a portrait configured).
+        /// If no position provided the engine will place the portrait based on the portrait configuration (<see cref="ISayConfig.PortraitConfig"/>),
+        /// assuming there is a portrait configuration. 
+        /// The interface for selecting the default portrait position (if none is passed here) is <see cref="ISayLocationProvider"/> and you
+        /// can override it if needed to provide default portrait (and text) locations.</param>
+		Task SayAsync(string text, PointF? textPosition = null, PointF? portraitPosition = null);
 	}
 }
-

--- a/Source/Engine/AGS.Engine/ComponentsFramework/Templates/AGSCharacter.generated.cs
+++ b/Source/Engine/AGS.Engine/ComponentsFramework/Templates/AGSCharacter.generated.cs
@@ -533,9 +533,9 @@ namespace AGS.Engine
             get { return _sayComponent.OnBeforeSay; } 
         }
 
-        public Task SayAsync(String text)
+        public Task SayAsync(String text, PointF? textPosition = null, PointF? portraitPosition = null)
         {
-            return _sayComponent.SayAsync(text);
+            return _sayComponent.SayAsync(text, textPosition, portraitPosition);
         }
 
         #endregion

--- a/Source/Engine/AGS.Engine/Objects/Characters/Talking/AGSSayComponent.cs
+++ b/Source/Engine/AGS.Engine/Objects/Characters/Talking/AGSSayComponent.cs
@@ -46,7 +46,7 @@ namespace AGS.Engine
             entity.Bind<IOutfitComponent>(c => _outfit = c, _ => _outfit = null);
         }
 
-		public async Task SayAsync(string text)
+        public async Task SayAsync(string text, PointF? textPosition = null, PointF? portraitPosition = null)
 		{
 			if (_state.Cutscene.IsSkipping)
 			{
@@ -59,9 +59,11 @@ namespace AGS.Engine
             text = speech.Text;
 
             ISayLocation location = getLocation(text);
-            IObject portrait = showPortrait(location);
+            var textLocation = textPosition ?? location.TextLocation;
+            portraitPosition = portraitPosition ?? location.PortraitLocation;
+            IObject portrait = showPortrait(portraitPosition);
 			ILabel label = _factory.UI.GetLabel($"Say: {text}", text, SpeechConfig.LabelSize.Width, 
-                SpeechConfig.LabelSize.Height, location.TextLocation.X, location.TextLocation.Y,
+                SpeechConfig.LabelSize.Height, textLocation.X, textLocation.Y,
                 config: SpeechConfig.TextConfig, addToUi: false);
 			label.RenderLayer = AGSLayers.Speech;
 			label.Border = SpeechConfig.Border;
@@ -86,16 +88,16 @@ namespace AGS.Engine
             if (_outfit != null) setAnimation(_outfit.Outfit[AGSOutfit.Idle]);
 		}
 
-        private IObject showPortrait(ISayLocation location)
+        private IObject showPortrait(PointF? portraitLocation)
         {
-            if (location.PortraitLocation == null) return null;
+            if (portraitLocation == null) return null;
             var portraitConfig = SpeechConfig.PortraitConfig;
             if (portraitConfig == null) return null;
             IObject portrait = portraitConfig.Portrait;
             if (portrait != null)
             {
                 portrait.Visible = true;
-                portrait.Position = new Position(location.PortraitLocation.Value);
+                portrait.Position = new Position(portraitLocation.Value);
             }
             return portrait;
         }


### PR DESCRIPTION
This is the equivalent to "SayAt" in AGS, you can now override the text position by doing: "await cEgo.SayAsync("Hello!", (100, 50));"

You can also override the portrait position (if there's a configured portrait): "await cEgo.SayAsync("Hello!", portraitPosition: (100, 50));"